### PR TITLE
fix(tui): files tab category filter not working

### DIFF
--- a/internal/chezmoi/service.go
+++ b/internal/chezmoi/service.go
@@ -47,9 +47,6 @@ func (s *Service) ManagedFilesWithFilter(filter EntryFilter) ([]string, error) {
 	return s.client.ManagedWithFilter(filter)
 }
 func (s *Service) IgnoredFiles() ([]string, error) { return s.client.Ignored() }
-func (s *Service) IgnoredFilesWithFilter(filter EntryFilter) ([]string, error) {
-	return s.client.IgnoredWithFilter(filter)
-}
 
 func (s *Service) UnmanagedFiles(filter ...EntryFilter) ([]string, error) {
 	return s.client.Unmanaged(filter...)

--- a/internal/chezmoi/types.go
+++ b/internal/chezmoi/types.go
@@ -37,13 +37,21 @@ func (f EntryFilter) IsZero() bool {
 
 func entryFilterArgs(f EntryFilter) []string {
 	var args []string
-	for _, t := range f.Include {
-		args = append(args, "--include="+string(t))
+	if len(f.Include) > 0 {
+		args = append(args, "--include="+joinEntryTypes(f.Include))
 	}
-	for _, t := range f.Exclude {
-		args = append(args, "--exclude="+string(t))
+	if len(f.Exclude) > 0 {
+		args = append(args, "--exclude="+joinEntryTypes(f.Exclude))
 	}
 	return args
+}
+
+func joinEntryTypes(types []EntryType) string {
+	parts := make([]string, len(types))
+	for i, t := range types {
+		parts[i] = string(t)
+	}
+	return strings.Join(parts, ",")
 }
 
 // FileStatus is a parsed line from `chezmoi status`.

--- a/internal/chezmoi/types_test.go
+++ b/internal/chezmoi/types_test.go
@@ -14,10 +14,8 @@ func TestEntryFilterArgsBuildsLongFlags(t *testing.T) {
 	})
 
 	want := []string{
-		"--include=files",
-		"--include=templates",
-		"--exclude=dirs",
-		"--exclude=scripts",
+		"--include=files,templates",
+		"--exclude=dirs,scripts",
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("entryFilterArgs() = %#v, want %#v", got, want)

--- a/internal/tui/files_commands.go
+++ b/internal/tui/files_commands.go
@@ -34,13 +34,7 @@ func (m Model) loadManagedCmd() tea.Cmd {
 func (m Model) loadIgnoredCmd() tea.Cmd {
 	gen := m.gen
 	return func() tea.Msg {
-		var files []string
-		var err error
-		if m.filesTab.entryFilter.IsZero() {
-			files, err = m.service.IgnoredFiles()
-		} else {
-			files, err = m.service.IgnoredFilesWithFilter(m.filesTab.entryFilter)
-		}
+		files, err := m.service.IgnoredFiles()
 		return chezmoiIgnoredLoadedMsg{files: files, err: err, gen: gen}
 	}
 }

--- a/internal/tui/files_view.go
+++ b/internal/tui/files_view.go
@@ -372,11 +372,15 @@ func (m Model) renderManagedStatusBar() string {
 	}
 
 	filterChip := "[filter:all]"
-	switch {
-	case len(m.filesTab.entryFilter.Exclude) > 0:
-		filterChip = fmt.Sprintf("[filter:%d excluded]", len(m.filesTab.entryFilter.Exclude))
-	case len(m.filesTab.entryFilter.Include) > 0:
-		filterChip = fmt.Sprintf("[filter:%d included]", len(m.filesTab.entryFilter.Include))
+	if m.filesTab.viewMode == managedViewIgnored {
+		filterChip = "[filter:N/A]"
+	} else {
+		switch {
+		case len(m.filesTab.entryFilter.Exclude) > 0:
+			filterChip = fmt.Sprintf("[filter:%d excluded]", len(m.filesTab.entryFilter.Exclude))
+		case len(m.filesTab.entryFilter.Include) > 0:
+			filterChip = fmt.Sprintf("[filter:%d included]", len(m.filesTab.entryFilter.Include))
+		}
 	}
 	viewChip := fmt.Sprintf("[view:%s]", strings.ToLower(managedViewModeLabel(m.filesTab.viewMode)))
 	status = strings.TrimRight(status, " ") + " " + viewChip + " " + filterChip + " "

--- a/internal/tui/view_overlays.go
+++ b/internal/tui/view_overlays.go
@@ -145,6 +145,10 @@ func (m Model) renderViewPickerMenu() string {
 	b.WriteString("\n")
 	b.WriteString(activeTheme.DimText.Render("  Type Filters"))
 	b.WriteString("\n")
+	if m.overlays.viewPickerPendingMode == managedViewIgnored {
+		b.WriteString(activeTheme.DimText.Render("  filters not supported for ignored"))
+		b.WriteString("\n")
+	}
 
 	for _, cat := range m.overlays.filterCategories {
 		var line string
@@ -197,6 +201,10 @@ func (m Model) renderFilterOverlay() string {
 	var b strings.Builder
 	b.WriteString("\n  Entry Type Filter\n")
 	b.WriteString("  " + strings.Repeat("─", 30) + "\n")
+	if m.filesTab.viewMode == managedViewIgnored {
+		b.WriteString(activeTheme.DimText.Render("  filters not supported for ignored"))
+		b.WriteString("\n")
+	}
 
 	for i, cat := range m.overlays.filterCategories {
 		isSelected := i == m.overlays.filterCursor


### PR DESCRIPTION
Use comma-separated --include/--exclude flags (chezmoi only honors the last flag per kind) and switch from exclude to include semantics since entry types overlap (a template is also a file). Show [filter:N/A] on the Ignored view which does not support filtering.