### PR TITLE
fix: classify script dest-side R status as pending script run

### DIFF
--- a/internal/chezmoi/chezmoi_test.go
+++ b/internal/chezmoi/chezmoi_test.go
@@ -86,6 +86,7 @@ func TestFileStatusSideLabel(t *testing.T) {
 		{path: "/home/user/.bashrc", src: 'D', dest: ' ', label: "pending apply"},
 		{path: "/home/user/.bashrc", src: 'R', dest: ' ', label: "pending apply"},
 		{path: "/home/user/.chezmoiscripts/run_once.sh", src: 'R', dest: ' ', label: "pending script run"},
+		{path: "/home/user/.chezmoiscripts/run_once.sh", src: ' ', dest: 'R', label: "pending script run"},
 		{path: "/home/user/.bashrc", src: ' ', dest: 'M', label: "target changed"},
 		{path: "/home/user/.bashrc", src: ' ', dest: 'D', label: "target changed"},
 		{path: "/home/user/.bashrc", src: ' ', dest: ' ', label: ""},

--- a/internal/chezmoi/types.go
+++ b/internal/chezmoi/types.go
@@ -67,7 +67,7 @@ type FileStatus struct {
 func (f FileStatus) SideLabel() string {
 	src := f.SourceStatus != ' '
 	dest := f.DestStatus != ' '
-	if f.IsScript() && f.SourceStatus == 'R' && !dest {
+	if f.IsScript() && (f.SourceStatus == 'R' || f.DestStatus == 'R') {
 		return "pending script run"
 	}
 	switch {


### PR DESCRIPTION
Scripts with `·R` status (dest-side R) were mislabeled as "target changed". Scripts don't have targets — this now correctly shows "pending script run".