### PR TITLE
feat: replace apply confirm dialog with force/interactive selector

### DIFF
--- a/internal/chezmoi/client.go
+++ b/internal/chezmoi/client.go
@@ -356,6 +356,14 @@ func (c *Client) ApplyAllCmd() *exec.Cmd {
 	return exec.Command(c.binary(), "apply")
 }
 
+func (c *Client) ApplyForceCmd(filePath string) *exec.Cmd {
+	return exec.Command(c.binary(), "apply", "--force", filePath)
+}
+
+func (c *Client) ApplyAllForceCmd() *exec.Cmd {
+	return exec.Command(c.binary(), "apply", "--force")
+}
+
 func (c *Client) ApplyDryRunCmd() *exec.Cmd {
 	return exec.Command(c.binary(), "apply", "--dry-run", "-v")
 }

--- a/internal/chezmoi/service.go
+++ b/internal/chezmoi/service.go
@@ -240,6 +240,20 @@ func (s *Service) ApplyAllCmd() *exec.Cmd {
 	return s.client.ApplyAllCmd()
 }
 
+func (s *Service) ApplyForceCmd(path string) *exec.Cmd {
+	if s.policy.IsReadOnly() {
+		return nil
+	}
+	return s.client.ApplyForceCmd(path)
+}
+
+func (s *Service) ApplyAllForceCmd() *exec.Cmd {
+	if s.policy.IsReadOnly() {
+		return nil
+	}
+	return s.client.ApplyAllForceCmd()
+}
+
 func (s *Service) ApplyRefreshCmd() *exec.Cmd {
 	if s.policy.IsReadOnly() {
 		return nil

--- a/internal/chezmoi/service_test.go
+++ b/internal/chezmoi/service_test.go
@@ -103,6 +103,12 @@ func TestServiceInteractiveCmdsNilInReadOnly(t *testing.T) {
 	if svc.ApplyAllCmd() != nil {
 		t.Error("expected ApplyAllCmd nil in read-only mode")
 	}
+	if svc.ApplyForceCmd("/home/test/.bashrc") != nil {
+		t.Error("expected ApplyForceCmd nil in read-only mode")
+	}
+	if svc.ApplyAllForceCmd() != nil {
+		t.Error("expected ApplyAllForceCmd nil in read-only mode")
+	}
 	if svc.UpdateCmd() != nil {
 		t.Error("expected UpdateCmd nil in read-only mode")
 	}

--- a/internal/tui/commands_exec.go
+++ b/internal/tui/commands_exec.go
@@ -14,7 +14,7 @@ func (m Model) executeChezmoiCommand(id chezmoiCommandID) (tea.Model, tea.Cmd) {
 	switch id {
 	// --- Shell-out commands (need TTY for sudo/interactive scripts) ---
 	case chezmoiCmdApply:
-		// Dry-run preview: show diff first, then confirm via shell-out
+		// Dry-run preview: show diff first, then choose force vs interactive apply.
 		m.ui.busyAction = true
 		m.diff.previewApply = true
 		return m, func() tea.Msg {

--- a/internal/tui/confirm_golden_test.go
+++ b/internal/tui/confirm_golden_test.go
@@ -1,0 +1,24 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/x/exp/golden"
+)
+
+func TestGoldenApplyConfirm(t *testing.T) {
+	t.Run("force_selected", func(t *testing.T) {
+		m := newTestModel(WithSize(80, 24))
+		m = m.showConfirmScreen(chezmoiActionApplyAll, "apply all changes to destination")
+		output := stripForGolden(m.renderConfirmScreen())
+		golden.RequireEqual(t, []byte(output))
+	})
+
+	t.Run("interactive_selected", func(t *testing.T) {
+		m := newTestModel(WithSize(80, 24))
+		m = m.showConfirmScreen(chezmoiActionApplyAll, "apply all changes to destination")
+		m.overlays.applyForce = false
+		output := stripForGolden(m.renderConfirmScreen())
+		golden.RequireEqual(t, []byte(output))
+	})
+}

--- a/internal/tui/confirm_keys_test.go
+++ b/internal/tui/confirm_keys_test.go
@@ -1,6 +1,8 @@
 package tui
 
 import (
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -399,6 +401,9 @@ func TestApplyConfirmCancel(t *testing.T) {
 			if updated.overlays.applyForce || updated.overlays.confirmAction != chezmoiActionNone {
 				t.Fatalf("expected overlay state cleared, got force=%v action=%d", updated.overlays.applyForce, updated.overlays.confirmAction)
 			}
+			if updated.overlays.applyWrapTTY {
+				t.Fatal("expected applyWrapTTY=false after cancel")
+			}
 		})
 	}
 }
@@ -473,6 +478,27 @@ func TestApplyConfirmDescriptions(t *testing.T) {
 	}
 }
 
+func TestWrapApplyConfirmCmd(t *testing.T) {
+	cmd := exec.Command("/bin/true")
+
+	unwrapped := wrapApplyConfirmCmd(cmd, false)
+	if unwrapped != cmd {
+		t.Fatal("expected wrapApplyConfirmCmd(false) to return original cmd")
+	}
+
+	wrapped := wrapApplyConfirmCmd(cmd, true)
+	if wrapped == nil {
+		t.Fatal("expected wrapped cmd")
+		return
+	}
+	if filepath.Base(wrapped.Path) != "sh" {
+		t.Fatalf("expected wrapped command to use sh, got %q", wrapped.Path)
+	}
+	if !containsAny(strings.Join(wrapped.Args, " "), "chezmoi-wrap", "Press Enter to continue") {
+		t.Fatalf("expected wrap args to include shell wrapper, got %v", wrapped.Args)
+	}
+}
+
 func TestPreviewApplyEnterOpensSelector(t *testing.T) {
 	m := newTestModel(WithTab(3))
 	m.view = DiffScreen
@@ -491,6 +517,9 @@ func TestPreviewApplyEnterOpensSelector(t *testing.T) {
 	}
 	if !updated.overlays.applyForce {
 		t.Fatal("expected applyForce=true by default")
+	}
+	if !updated.overlays.applyWrapTTY {
+		t.Fatal("expected preview apply selector to preserve wrapped output")
 	}
 	if updated.diff.previewApply || updated.diff.lines != nil {
 		t.Fatal("expected diff state cleared")

--- a/internal/tui/confirm_keys_test.go
+++ b/internal/tui/confirm_keys_test.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"strings"
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
@@ -126,12 +127,6 @@ func TestConfirmDispatchesAction(t *testing.T) {
 			action:   chezmoiActionGitUndoCommit,
 			label:    "undo last commit (changes return to staged)",
 			wantBusy: true,
-		},
-		{
-			name:     "apply_all",
-			action:   chezmoiActionApplyAll,
-			label:    "apply all changes to destination",
-			wantBusy: false, // uses tea.ExecProcess
 		},
 		{
 			name:     "update",
@@ -322,5 +317,182 @@ func TestDiscardKeyOnUnpushedOpensUndoConfirm(t *testing.T) {
 	}
 	if updated.overlays.confirmAction != chezmoiActionGitUndoCommit {
 		t.Fatalf("expected confirmAction=GitUndoCommit, got %d", updated.overlays.confirmAction)
+	}
+}
+
+// --- Apply confirm selector tests ---
+
+func newApplyConfirmModel(action chezmoiAction, label string) Model {
+	m := newConfirmModel(action, label)
+	m.overlays.applyForce = true // default for apply actions
+	return m
+}
+
+func TestApplyConfirmDefaults(t *testing.T) {
+	t.Run("apply_action_defaults_to_force", func(t *testing.T) {
+		m := NewModel(Options{Service: testService()})
+		m.width, m.height = 120, 40
+		m = m.showConfirmScreen(chezmoiActionApplyAll, "apply all")
+		if !m.overlays.applyForce || m.view != ConfirmScreen {
+			t.Fatalf("expected applyForce=true and ConfirmScreen, got force=%v view=%d", m.overlays.applyForce, m.view)
+		}
+	})
+	t.Run("non_apply_action_no_force", func(t *testing.T) {
+		m := NewModel(Options{Service: testService()})
+		m.width, m.height = 120, 40
+		m = m.showConfirmScreen(chezmoiActionPush, "push")
+		if m.overlays.applyForce {
+			t.Fatal("expected applyForce=false for non-apply action")
+		}
+	})
+}
+
+func TestApplyConfirmNavigation(t *testing.T) {
+	tests := []struct {
+		name string
+		key  tea.KeyPressMsg
+		want bool
+	}{
+		{"right_selects_interactive", specialKey(tea.KeyRight), false},
+		{"left_selects_force", specialKey(tea.KeyLeft), true},
+		{"h_selects_force", runeKey("h"), true},
+		{"l_selects_interactive", runeKey("l"), false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newApplyConfirmModel(chezmoiActionApplyAll, "apply all")
+			m.overlays.applyForce = !tc.want // start opposite so the key has to change it
+			updated, _ := sendKey(t, m, tc.key)
+			if updated.overlays.applyForce != tc.want {
+				t.Fatalf("expected applyForce=%v, got %v", tc.want, updated.overlays.applyForce)
+			}
+		})
+	}
+	t.Run("tab_toggles", func(t *testing.T) {
+		m := newApplyConfirmModel(chezmoiActionApplyAll, "apply all")
+		updated, _ := sendKey(t, m, specialKey(tea.KeyTab))
+		if updated.overlays.applyForce {
+			t.Fatal("expected applyForce=false after first Tab")
+		}
+		updated, _ = sendKey(t, updated, specialKey(tea.KeyTab))
+		if !updated.overlays.applyForce {
+			t.Fatal("expected applyForce=true after second Tab")
+		}
+	})
+}
+
+func TestApplyConfirmCancel(t *testing.T) {
+	tests := []struct {
+		name string
+		key  tea.KeyPressMsg
+	}{
+		{"esc", specialKey(tea.KeyEscape)},
+		{"n", runeKey("n")},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newApplyConfirmModel(chezmoiActionApplyAll, "apply all")
+			updated, _ := sendKey(t, m, tc.key)
+			if updated.view != StatusScreen {
+				t.Fatalf("expected StatusScreen, got %d", updated.view)
+			}
+			if updated.overlays.applyForce || updated.overlays.confirmAction != chezmoiActionNone {
+				t.Fatalf("expected overlay state cleared, got force=%v action=%d", updated.overlays.applyForce, updated.overlays.confirmAction)
+			}
+		})
+	}
+}
+
+func TestApplyConfirmIgnoresKeys(t *testing.T) {
+	for _, k := range []tea.KeyPressMsg{runeKey("y"), runeKey("j"), runeKey("q")} {
+		m := newApplyConfirmModel(chezmoiActionApplyAll, "apply all")
+		updated, _ := sendKey(t, m, k)
+		if updated.view != ConfirmScreen || updated.overlays.confirmAction != chezmoiActionApplyAll {
+			t.Fatalf("key %v should be ignored in apply confirm, got view=%d action=%d", k, updated.view, updated.overlays.confirmAction)
+		}
+	}
+}
+
+func TestApplyConfirmEnterDispatches(t *testing.T) {
+	m := newApplyConfirmModel(chezmoiActionApplyAll, "apply all")
+	updated, cmd := sendKey(t, m, specialKey(tea.KeyEnter))
+	if updated.view != StatusScreen || updated.overlays.confirmAction != chezmoiActionNone || updated.overlays.applyForce {
+		t.Fatalf("expected clean state after confirm, got view=%d action=%d force=%v", updated.view, updated.overlays.confirmAction, updated.overlays.applyForce)
+	}
+	if cmd == nil {
+		t.Fatal("expected non-nil cmd after apply confirm")
+	}
+}
+
+func TestApplyConfirmExecCmd(t *testing.T) {
+	tests := []struct {
+		name     string
+		action   chezmoiAction
+		path     string
+		force    bool
+		wantArgs string
+	}{
+		{"force_apply_all", chezmoiActionApplyAll, "", true, "apply --force"},
+		{"interactive_apply_all", chezmoiActionApplyAll, "", false, "apply"},
+		{"force_managed", chezmoiActionApplyManaged, "/home/test/.bashrc", true, "apply --force /home/test/.bashrc"},
+		{"interactive_managed", chezmoiActionApplyManaged, "/home/test/.bashrc", false, "apply /home/test/.bashrc"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newApplyConfirmModel(tc.action, "apply")
+			m.overlays.confirmPath = tc.path
+			cmd := m.applyConfirmExecCmd(tc.action, tc.path, tc.force)
+			if cmd == nil {
+				t.Fatal("expected non-nil exec.Cmd")
+				return
+			}
+			got := strings.Join(cmd.Args[1:], " ")
+			if got != tc.wantArgs {
+				t.Fatalf("expected args %q, got %q", tc.wantArgs, got)
+			}
+		})
+	}
+}
+
+func TestApplyConfirmDescriptions(t *testing.T) {
+	tests := []struct {
+		action chezmoiAction
+		force  bool
+		want   string
+	}{
+		{chezmoiActionApplyAll, true, "Applies all changes with --force (skips chezmoi prompts)"},
+		{chezmoiActionApplyAll, false, "Runs plain chezmoi apply and lets chezmoi prompt as needed"},
+		{chezmoiActionApplyFile, true, "Applies the selected file with --force (skips chezmoi prompts)"},
+		{chezmoiActionApplyFile, false, "Runs plain chezmoi apply for the selected file and lets chezmoi prompt if needed"},
+		{chezmoiActionApplyManaged, true, "Applies the selected file with --force (skips chezmoi prompts)"},
+	}
+	for _, tc := range tests {
+		if got := applyConfirmDescription(tc.action, tc.force); got != tc.want {
+			t.Fatalf("applyConfirmDescription(%d, %v) = %q, want %q", tc.action, tc.force, got, tc.want)
+		}
+	}
+}
+
+func TestPreviewApplyEnterOpensSelector(t *testing.T) {
+	m := newTestModel(WithTab(3))
+	m.view = DiffScreen
+	m.activeTab = 3
+	m.diff.previewApply = true
+	m.diff.content = "preview"
+	m.diff.lines = []string{"+line 1"}
+
+	updated, cmd := sendKey(t, m, specialKey(tea.KeyEnter))
+
+	if cmd != nil {
+		t.Fatal("expected no cmd — should transition to selector only")
+	}
+	if updated.view != ConfirmScreen || updated.overlays.confirmAction != chezmoiActionApplyAll {
+		t.Fatalf("expected ConfirmScreen with ApplyAll, got view=%d action=%d", updated.view, updated.overlays.confirmAction)
+	}
+	if !updated.overlays.applyForce {
+		t.Fatal("expected applyForce=true by default")
+	}
+	if updated.diff.previewApply || updated.diff.lines != nil {
+		t.Fatal("expected diff state cleared")
 	}
 }

--- a/internal/tui/files_actions.go
+++ b/internal/tui/files_actions.go
@@ -174,6 +174,7 @@ func (m Model) executeFilesAction(action chezmoiAction) (tea.Model, tea.Cmd) {
 		m.overlays.confirmLabel = "apply " + path
 		m.overlays.confirmPath = path
 		m.overlays.applyForce = true
+		m.overlays.applyWrapTTY = false
 		m.view = ConfirmScreen
 		return m, nil
 

--- a/internal/tui/files_actions.go
+++ b/internal/tui/files_actions.go
@@ -173,6 +173,7 @@ func (m Model) executeFilesAction(action chezmoiAction) (tea.Model, tea.Cmd) {
 		m.overlays.confirmAction = chezmoiActionApplyManaged
 		m.overlays.confirmLabel = "apply " + path
 		m.overlays.confirmPath = path
+		m.overlays.applyForce = true
 		m.view = ConfirmScreen
 		return m, nil
 

--- a/internal/tui/files_keys_test.go
+++ b/internal/tui/files_keys_test.go
@@ -454,6 +454,7 @@ func TestOpaqueDirPopulatedMsgAppliesChildren(t *testing.T) {
 	got := findTreeNodeByRelPath(updated.filesTab.views[managedViewManaged].tree, "opaque")
 	if got == nil {
 		t.Fatal("expected opaque node")
+		return
 	}
 	if got.loading || got.loadingRequest != 0 {
 		t.Fatalf("expected loading cleared, got loading=%v request=%d", got.loading, got.loadingRequest)
@@ -498,6 +499,7 @@ func TestOpaqueDirPopulatedMsgOldRequestIgnored(t *testing.T) {
 	got := findTreeNodeByRelPath(updated.filesTab.views[managedViewManaged].tree, "opaque")
 	if got == nil {
 		t.Fatal("expected opaque node")
+		return
 	}
 	if !got.loading || got.loadingRequest != 2 {
 		t.Fatalf("expected loading to remain for active request, got loading=%v request=%d", got.loading, got.loadingRequest)
@@ -536,6 +538,7 @@ func TestOpaqueDirPopulatedMsgStaleGenClearsMatchingLoading(t *testing.T) {
 	got := findTreeNodeByRelPath(updated.filesTab.views[managedViewManaged].tree, "opaque")
 	if got == nil {
 		t.Fatal("expected opaque node")
+		return
 	}
 	if got.loading || got.loadingRequest != 0 {
 		t.Fatalf("expected matching loading cleared, got loading=%v request=%d", got.loading, got.loadingRequest)
@@ -585,6 +588,7 @@ func TestOpaqueDirPopulatedMsgPreservesFilteredProjection(t *testing.T) {
 	node := findTreeNodeByRelPath(m.filesTab.views[managedViewUnmanaged].tree, "workspace")
 	if node == nil {
 		t.Fatal("expected workspace node")
+		return
 	}
 	node.loading = true
 	node.loadingRequest = 1

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -167,6 +167,39 @@ var ChezConfirmKeys = ChezConfirmKeyMap{
 	),
 }
 
+// ── Apply Confirm Selector Bindings ────────────────────────────────
+
+type ChezApplyConfirmKeyMap struct {
+	Left    key.Binding
+	Right   key.Binding
+	Toggle  key.Binding
+	Confirm key.Binding
+	Cancel  key.Binding
+}
+
+var ChezApplyConfirmKeys = ChezApplyConfirmKeyMap{
+	Left: key.NewBinding(
+		key.WithKeys("left", "h"),
+		key.WithHelp("←/→", "Switch"),
+	),
+	Right: key.NewBinding(
+		key.WithKeys("right", "l"),
+		key.WithHelp("←/→", "Switch"),
+	),
+	Toggle: key.NewBinding(
+		key.WithKeys("tab"),
+		key.WithHelp("Tab", "Switch"),
+	),
+	Confirm: key.NewBinding(
+		key.WithKeys("enter"),
+		key.WithHelp("Enter", "Confirm"),
+	),
+	Cancel: key.NewBinding(
+		key.WithKeys("n", "esc"),
+		key.WithHelp("n/esc", "Cancel"),
+	),
+}
+
 // ── Changes Tab Bindings ───────────────────────────────────────────
 
 type ChezChangesKeyMap struct {

--- a/internal/tui/status_actions.go
+++ b/internal/tui/status_actions.go
@@ -393,6 +393,7 @@ func (m Model) showConfirmScreen(action chezmoiAction, label string) Model {
 	m.overlays.confirmAction = action
 	m.overlays.confirmLabel = label
 	m.overlays.applyForce = isApplyAction(action)
+	m.overlays.applyWrapTTY = false
 	m.view = ConfirmScreen
 	return m
 }

--- a/internal/tui/status_actions.go
+++ b/internal/tui/status_actions.go
@@ -392,6 +392,7 @@ func actionRequiresWrite(action chezmoiAction) bool {
 func (m Model) showConfirmScreen(action chezmoiAction, label string) Model {
 	m.overlays.confirmAction = action
 	m.overlays.confirmLabel = label
+	m.overlays.applyForce = isApplyAction(action)
 	m.view = ConfirmScreen
 	return m
 }

--- a/internal/tui/status_commands.go
+++ b/internal/tui/status_commands.go
@@ -85,11 +85,6 @@ func (m Model) reAddSelectionCmd(paths []string) tea.Cmd {
 	}
 }
 
-func (m Model) applyFileCmd(path string) tea.Cmd {
-	cmd := m.service.ApplyCmd(path)
-	return execCmdOrUnsupported(chezmoiActionApplyFile, cmd, "chezmoi: apply not supported")
-}
-
 func (m Model) applyAllCmd() tea.Cmd {
 	cmd := m.service.ApplyAllCmd()
 	return execCmdOrUnsupported(chezmoiActionApplyAll, cmd, "chezmoi: apply not supported")

--- a/internal/tui/status_update.go
+++ b/internal/tui/status_update.go
@@ -479,6 +479,7 @@ func (m Model) handleConfirmKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		m.overlays.confirmPath = ""
 		m.overlays.confirmPaths = nil
 		m.overlays.applyForce = false
+		m.overlays.applyWrapTTY = false
 		switch action {
 		case chezmoiActionUpdate:
 			return m, m.updateCmd()
@@ -548,6 +549,7 @@ func (m Model) handleConfirmKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		m.overlays.confirmPath = ""
 		m.overlays.confirmPaths = nil
 		m.overlays.applyForce = false
+		m.overlays.applyWrapTTY = false
 		return m, nil
 	}
 	return m, nil
@@ -575,6 +577,7 @@ func (m Model) handleApplyConfirmKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) 
 		m.overlays.confirmPath = ""
 		m.overlays.confirmPaths = nil
 		m.overlays.applyForce = false
+		m.overlays.applyWrapTTY = false
 		return m, nil
 	}
 	return m, nil
@@ -587,14 +590,17 @@ func (m Model) executeApplyConfirm() (tea.Model, tea.Cmd) {
 	action := m.overlays.confirmAction
 	savedPath := m.overlays.confirmPath
 	force := m.overlays.applyForce
+	wrapTTY := m.overlays.applyWrapTTY
 
 	m.overlays.confirmAction = chezmoiActionNone
 	m.overlays.confirmLabel = ""
 	m.overlays.confirmPath = ""
 	m.overlays.confirmPaths = nil
 	m.overlays.applyForce = false
+	m.overlays.applyWrapTTY = false
 
 	cmd := m.applyConfirmExecCmd(action, savedPath, force)
+	cmd = wrapApplyConfirmCmd(cmd, wrapTTY)
 	switch action {
 	case chezmoiActionApplyAll:
 		return m, execCmdOrUnsupported(chezmoiActionApplyAll, cmd, "chezmoi: apply not supported")
@@ -631,4 +637,11 @@ func (m Model) applyConfirmExecCmd(action chezmoiAction, savedPath string, force
 	default:
 		return nil
 	}
+}
+
+func wrapApplyConfirmCmd(cmd *exec.Cmd, wrapTTY bool) *exec.Cmd {
+	if !wrapTTY {
+		return cmd
+	}
+	return wrapWithPressEnter(cmd)
 }

--- a/internal/tui/status_update.go
+++ b/internal/tui/status_update.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"time"
 
 	"charm.land/bubbles/v2/key"
@@ -463,6 +464,10 @@ func (m Model) handleStatusRefresh() (tea.Model, tea.Cmd) {
 // --- Confirm dialog key handler ---
 
 func (m Model) handleConfirmKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	if isApplyAction(m.overlays.confirmAction) {
+		return m.handleApplyConfirmKeys(msg)
+	}
+
 	switch {
 	case key.Matches(msg, ChezConfirmKeys.Confirm):
 		m.view = StatusScreen
@@ -473,24 +478,14 @@ func (m Model) handleConfirmKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		m.overlays.confirmLabel = ""
 		m.overlays.confirmPath = ""
 		m.overlays.confirmPaths = nil
+		m.overlays.applyForce = false
 		switch action {
 		case chezmoiActionUpdate:
 			return m, m.updateCmd()
-		case chezmoiActionApplyAll:
-			return m, m.applyAllCmd()
-		case chezmoiActionApplyFile:
-			path := m.currentFilePath()
-			if path != "" {
-				return m, m.applyFileCmd(path)
-			}
 		case chezmoiActionForgetFile:
 			if savedPath != "" {
 				m.ui.busyAction = true
 				return m, tea.Batch(m.ui.loadingSpinner.Tick, m.forgetFileCmd(savedPath))
-			}
-		case chezmoiActionApplyManaged:
-			if savedPath != "" {
-				return m, m.applyFileCmd(savedPath)
 			}
 		case chezmoiActionPush:
 			m.ui.busyAction = true
@@ -552,7 +547,88 @@ func (m Model) handleConfirmKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		m.overlays.confirmLabel = ""
 		m.overlays.confirmPath = ""
 		m.overlays.confirmPaths = nil
+		m.overlays.applyForce = false
 		return m, nil
 	}
 	return m, nil
+}
+
+// handleApplyConfirmKeys handles the two-option apply confirm selector
+// (Force Apply vs Interactive Apply).
+func (m Model) handleApplyConfirmKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	switch {
+	case key.Matches(msg, ChezApplyConfirmKeys.Left):
+		m.overlays.applyForce = true
+		return m, nil
+	case key.Matches(msg, ChezApplyConfirmKeys.Right):
+		m.overlays.applyForce = false
+		return m, nil
+	case key.Matches(msg, ChezApplyConfirmKeys.Toggle):
+		m.overlays.applyForce = !m.overlays.applyForce
+		return m, nil
+	case key.Matches(msg, ChezApplyConfirmKeys.Confirm):
+		return m.executeApplyConfirm()
+	case key.Matches(msg, ChezApplyConfirmKeys.Cancel):
+		m.view = StatusScreen
+		m.overlays.confirmAction = chezmoiActionNone
+		m.overlays.confirmLabel = ""
+		m.overlays.confirmPath = ""
+		m.overlays.confirmPaths = nil
+		m.overlays.applyForce = false
+		return m, nil
+	}
+	return m, nil
+}
+
+// executeApplyConfirm dispatches the apply command based on the selected mode
+// (force or interactive) and clears the confirm overlay state.
+func (m Model) executeApplyConfirm() (tea.Model, tea.Cmd) {
+	m.view = StatusScreen
+	action := m.overlays.confirmAction
+	savedPath := m.overlays.confirmPath
+	force := m.overlays.applyForce
+
+	m.overlays.confirmAction = chezmoiActionNone
+	m.overlays.confirmLabel = ""
+	m.overlays.confirmPath = ""
+	m.overlays.confirmPaths = nil
+	m.overlays.applyForce = false
+
+	cmd := m.applyConfirmExecCmd(action, savedPath, force)
+	switch action {
+	case chezmoiActionApplyAll:
+		return m, execCmdOrUnsupported(chezmoiActionApplyAll, cmd, "chezmoi: apply not supported")
+	case chezmoiActionApplyFile, chezmoiActionApplyManaged:
+		return m, execCmdOrUnsupported(chezmoiActionApplyFile, cmd, "chezmoi: apply not supported")
+	}
+	return m, nil
+}
+
+func (m Model) applyConfirmExecCmd(action chezmoiAction, savedPath string, force bool) *exec.Cmd {
+	switch action {
+	case chezmoiActionApplyAll:
+		if force {
+			return m.service.ApplyAllForceCmd()
+		}
+		return m.service.ApplyAllCmd()
+	case chezmoiActionApplyFile:
+		path := m.currentFilePath()
+		if path == "" {
+			return nil
+		}
+		if force {
+			return m.service.ApplyForceCmd(path)
+		}
+		return m.service.ApplyCmd(path)
+	case chezmoiActionApplyManaged:
+		if savedPath == "" {
+			return nil
+		}
+		if force {
+			return m.service.ApplyForceCmd(savedPath)
+		}
+		return m.service.ApplyCmd(savedPath)
+	default:
+		return nil
+	}
 }

--- a/internal/tui/testdata/TestGoldenApplyConfirm/force_selected.golden
+++ b/internal/tui/testdata/TestGoldenApplyConfirm/force_selected.golden
@@ -1,0 +1,19 @@
+
+
+
+
+
+          ╭──────────────────────────────────────────────────────────╮
+          │                                                          │
+          │                                                          │
+          │    apply all changes to destination                      │
+          │                                                          │
+          │    [ Force Apply ]   [ Interactive ]                     │
+          │                                                          │
+          │    Applies all changes with --force (skips chezmoi       │
+          │  prompts)                                                │
+          │                                                          │
+          │    ←/→ or Tab switch | Enter confirm | n/Esc cancel      │
+          │                                                          │
+          │                                                          │
+          ╰──────────────────────────────────────────────────────────╯

--- a/internal/tui/testdata/TestGoldenApplyConfirm/interactive_selected.golden
+++ b/internal/tui/testdata/TestGoldenApplyConfirm/interactive_selected.golden
@@ -1,0 +1,19 @@
+
+
+
+
+
+          ╭──────────────────────────────────────────────────────────╮
+          │                                                          │
+          │                                                          │
+          │    apply all changes to destination                      │
+          │                                                          │
+          │    [ Force Apply ]   [ Interactive ]                     │
+          │                                                          │
+          │    Runs plain chezmoi apply and lets chezmoi prompt as   │
+          │  needed                                                  │
+          │                                                          │
+          │    ←/→ or Tab switch | Enter confirm | n/Esc cancel      │
+          │                                                          │
+          │                                                          │
+          ╰──────────────────────────────────────────────────────────╯

--- a/internal/tui/types.go
+++ b/internal/tui/types.go
@@ -284,6 +284,7 @@ type overlayState struct {
 	confirmPath   string
 	confirmPaths  []string
 	applyForce    bool // true = Force Apply (default for apply actions)
+	applyWrapTTY  bool // true = keep apply output visible with wrapWithPressEnter
 }
 
 // isApplyAction returns true for actions that use the two-option apply confirm selector.

--- a/internal/tui/types.go
+++ b/internal/tui/types.go
@@ -283,6 +283,14 @@ type overlayState struct {
 	confirmLabel  string
 	confirmPath   string
 	confirmPaths  []string
+	applyForce    bool // true = Force Apply (default for apply actions)
+}
+
+// isApplyAction returns true for actions that use the two-option apply confirm selector.
+func isApplyAction(action chezmoiAction) bool {
+	return action == chezmoiActionApplyFile ||
+		action == chezmoiActionApplyAll ||
+		action == chezmoiActionApplyManaged
 }
 
 // diffViewState groups fields for the full-screen diff overlay.

--- a/internal/tui/update_crosscutting.go
+++ b/internal/tui/update_crosscutting.go
@@ -165,7 +165,7 @@ func (m Model) handleExecDone(msg chezmoiExecDoneMsg) (tea.Model, tea.Cmd) {
 	case chezmoiActionApplyFile:
 		m.ui.message = "applied file"
 	case chezmoiActionApplyAll:
-		m.ui.message = "applied all files"
+		m.ui.message = "apply complete"
 	case chezmoiActionUpdate:
 		m.ui.message = "update complete"
 	case chezmoiActionEditSource:

--- a/internal/tui/update_diff.go
+++ b/internal/tui/update_diff.go
@@ -36,7 +36,7 @@ func scrollViewport(vp *viewport.Model, msg tea.KeyPressMsg) bool {
 // --- Diff view key handler ---
 
 func (m Model) handleDiffKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
-	// Preview-apply mode: Esc cancels, Enter confirms and shells out
+	// Preview-apply mode: Esc cancels, Enter continues to the apply-mode selector.
 	if m.diff.previewApply {
 		switch {
 		case key.Matches(msg, ChezSharedKeys.Back):
@@ -48,14 +48,12 @@ func (m Model) handleDiffKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			return m, nil
 		case key.Matches(msg, ChezCommandKeys.Run): // Enter
 			m.diff.previewApply = false
-			m.view = StatusScreen
 			m.diff.content = ""
 			m.diff.lines = nil
 			m.diff.resetViewport()
-			// Shell-out to apply with full TTY (sudo/scripts need it)
-			cmd := m.service.ApplyAllCmd()
-			wrapped := wrapWithPressEnter(cmd)
-			return m, execCmdOrUnsupported(chezmoiActionApplyAll, wrapped, "chezmoi: apply not supported")
+			m.actions.show = false
+			m = m.showConfirmScreen(chezmoiActionApplyAll, "apply all changes to destination")
+			return m, nil
 		}
 		// Fall through to scroll keys below
 	}

--- a/internal/tui/update_diff.go
+++ b/internal/tui/update_diff.go
@@ -53,6 +53,7 @@ func (m Model) handleDiffKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			m.diff.resetViewport()
 			m.actions.show = false
 			m = m.showConfirmScreen(chezmoiActionApplyAll, "apply all changes to destination")
+			m.overlays.applyWrapTTY = true
 			return m, nil
 		}
 		// Fall through to scroll keys below

--- a/internal/tui/update_mouse_test.go
+++ b/internal/tui/update_mouse_test.go
@@ -108,6 +108,7 @@ func TestMouseClickFilesTreeOnSelectedDirectoryTogglesCollapse(t *testing.T) {
 	node := findTreeNodeByRelPath(updated.activeTree(), dirRel)
 	if node == nil {
 		t.Fatalf("expected directory %q to remain in tree", dirRel)
+		return
 	}
 	if node.expanded {
 		t.Fatalf("expected directory %q to be collapsed after click", dirRel)

--- a/internal/tui/view_overlays.go
+++ b/internal/tui/view_overlays.go
@@ -68,14 +68,63 @@ func (m Model) renderConfirmScreen() string {
 		label = "this action"
 	}
 
+	box := warningDialogBase.BorderForeground(activeTheme.Warning)
+
+	if isApplyAction(m.overlays.confirmAction) {
+		return lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center,
+			box.Render(m.renderApplyConfirmContent(label)))
+	}
+
 	content := fmt.Sprintf(
 		"\n  Are you sure you want to %s?\n\n  Press y to confirm, n or Esc to cancel.\n",
 		label,
 	)
-
-	box := warningDialogBase.BorderForeground(activeTheme.Warning)
-
 	return lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, box.Render(content))
+}
+
+func (m Model) renderApplyConfirmContent(label string) string {
+	forceLabel := "[ Force Apply ]"
+	interactiveLabel := "[ Interactive ]"
+
+	if m.overlays.applyForce {
+		forceLabel = activeTheme.Selected.Render(forceLabel)
+		interactiveLabel = activeTheme.DimText.Render(interactiveLabel)
+	} else {
+		forceLabel = activeTheme.DimText.Render(forceLabel)
+		interactiveLabel = activeTheme.Selected.Render(interactiveLabel)
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "\n  %s\n\n", label)
+	fmt.Fprintf(&b, "  %s   %s\n\n", forceLabel, interactiveLabel)
+
+	b.WriteString(activeTheme.DimText.Render("  " + applyConfirmDescription(m.overlays.confirmAction, m.overlays.applyForce)))
+	b.WriteString("\n\n")
+	b.WriteString(activeTheme.HintText.Render("  " + lipgloss.JoinHorizontal(lipgloss.Top,
+		"←/→ or Tab switch", " | ", "Enter confirm", " | ", "n/Esc cancel")))
+	b.WriteString("\n")
+
+	return b.String()
+}
+
+func applyConfirmDescription(action chezmoiAction, force bool) string {
+	switch action {
+	case chezmoiActionApplyAll:
+		if force {
+			return "Applies all changes with --force (skips chezmoi prompts)"
+		}
+		return "Runs plain chezmoi apply and lets chezmoi prompt as needed"
+	case chezmoiActionApplyFile, chezmoiActionApplyManaged:
+		if force {
+			return "Applies the selected file with --force (skips chezmoi prompts)"
+		}
+		return "Runs plain chezmoi apply for the selected file and lets chezmoi prompt if needed"
+	default:
+		if force {
+			return "Applies with --force (skips chezmoi prompts)"
+		}
+		return "Runs plain chezmoi apply and lets chezmoi prompt as needed"
+	}
 }
 
 func (m Model) renderChezmoiDiffStatus() string {
@@ -102,7 +151,7 @@ func (m Model) renderChezmoiDiffStatus() string {
 	var help string
 	switch {
 	case m.diff.previewApply:
-		help = m.helpHint("↑/↓ scroll | ^d/^u half-page | enter apply | esc cancel")
+		help = m.helpHint("↑/↓ scroll | ^d/^u half-page | enter choose mode | esc cancel")
 	case m.actions.show:
 		help = m.helpHint("↑/↓ navigate | enter select | esc back")
 	default:


### PR DESCRIPTION
Apply actions now show a two-option selector (Force Apply / Interactive) instead of a simple y/n prompt. Force Apply uses --force to skip chezmoi's redundant per-file prompts; Interactive preserves them. Commands tab preview-apply routes through the same selector. Non-apply confirms unchanged.

Also fixes pre-existing staticcheck SA5011 false positives from golangci-lint v2.11.3.