### PR TITLE
fix: resolve "p" key conflict between panel toggle and pull

### DIFF
--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -282,15 +282,20 @@ func (m Model) handleKeyMsg(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	tab = m.activeTabName()
 	if m.view == StatusScreen && (tab == "Status" || tab == "Files") {
 		if key.Matches(msg, ChezPanelKeys.Toggle) {
-			m.panel.toggle(m.width)
-			if m.panel.shouldShow(m.width) {
-				var panelCmd tea.Cmd
-				m, panelCmd = m.panelLoadForCurrentTab()
-				return m, panelCmd
+			// "p" is used for Pull on incoming rows — let it fall through
+			if msg.String() == "p" && tab == "Status" && m.currentChangesRow().section == changesSectionIncoming {
+				// fall through to handleStatusKeys
+			} else {
+				m.panel.toggle(m.width)
+				if m.panel.shouldShow(m.width) {
+					var panelCmd tea.Cmd
+					m, panelCmd = m.panelLoadForCurrentTab()
+					return m, panelCmd
+				}
+				// Panel hidden: reset focus to list
+				m.panel.focusZone = panelFocusList
+				return m, nil
 			}
-			// Panel hidden: reset focus to list
-			m.panel.focusZone = panelFocusList
-			return m, nil
 		}
 
 		if m.panel.shouldShow(m.width) {


### PR DESCRIPTION
Panel toggle handler intercepted "p" before the status tab handler, making Pull inaccessible on incoming section rows. Now lets "p" fall through to `handleStatusKeys` when cursor is on an incoming row, matching the existing "l" key conflict pattern for Files tab tree view.