### PR TITLE
feat: respect chezmoi diff.pager configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,18 @@ Defaults are shown in the YAML example above.
 | `commit_presets` | list of strings | Optional preset commit messages shown in the commit flow. |
 | `binary_path` | path to `chezmoi` binary (`~` supported) | Set only if `chezmoi` is not on `PATH`. |
 
+## Diff Pager Support
+
+chezit respects chezmoi's `diff.pager` setting. When a supported pager is configured, all diff surfaces (drift, git, apply preview, panel, full-screen) use the pager's styling instead of chezit's built-in coloring.
+
+```toml
+# ~/.config/chezmoi/chezmoi.toml
+[diff]
+    pager = "delta"
+```
+
+Supported pagers: `delta`, `bat`, `diff-so-fancy`. If the configured pager is missing or fails, chezit falls back silently to built-in styling. To request support for a new pager, open an issue or PR.
+
 ## Development
 
 Requires Go 1.26+ and [task](https://taskfile.dev/). Uses Bubble Tea v2, Lip Gloss v2, and Bubbles v2. Huh v2 is still pre-release.

--- a/cmd/chezit/main.go
+++ b/cmd/chezit/main.go
@@ -88,6 +88,11 @@ func runTUI(initialTab string) error {
 		debugLog = slog.New(slog.NewJSONHandler(f, nil))
 	}
 
+	var diffPagerCmd string
+	if diffCfg, err := svc.DiffConfig(); err == nil {
+		diffPagerCmd = diffCfg.Pager
+	}
+
 	opts := tui.Options{
 		Service:       svc,
 		EscBehavior:   tui.EscQuit,
@@ -95,6 +100,7 @@ func runTUI(initialTab string) error {
 		PanelMode:     cfg.Panel,
 		IconMode:      iconMode,
 		InitialTab:    initialTab,
+		DiffPagerCmd:  diffPagerCmd,
 		DebugLog:      debugLog,
 	}
 

--- a/internal/chezmoi/diffpager.go
+++ b/internal/chezmoi/diffpager.go
@@ -1,0 +1,25 @@
+package chezmoi
+
+import "encoding/json"
+
+// DiffConfig holds the diff-related settings from chezmoi's resolved config.
+type DiffConfig struct {
+	Pager string // e.g., "delta", "diff-so-fancy"
+}
+
+// DiffConfig parses diff.pager from chezmoi's resolved configuration.
+func (c *Client) DiffConfig() (DiffConfig, error) {
+	raw, err := c.DumpConfigJSON()
+	if err != nil {
+		return DiffConfig{}, err
+	}
+	var cfg struct {
+		Diff struct {
+			Pager string `json:"pager"`
+		} `json:"diff"`
+	}
+	if err := json.Unmarshal([]byte(raw), &cfg); err != nil {
+		return DiffConfig{}, err
+	}
+	return DiffConfig{Pager: cfg.Diff.Pager}, nil
+}

--- a/internal/chezmoi/diffpager_test.go
+++ b/internal/chezmoi/diffpager_test.go
@@ -1,68 +1,114 @@
 package chezmoi
 
 import (
-	"encoding/json"
+	"strings"
 	"testing"
 )
 
-func TestParseDiffConfig(t *testing.T) {
+func TestClientDiffConfig(t *testing.T) {
 	tests := []struct {
 		name      string
-		input     string
+		body      string
 		wantPager string
-		wantErr   bool
+		wantErr   string
 	}{
 		{
-			name:      "pager set",
-			input:     `{"diff":{"pager":"delta"}}`,
+			name: "pager set",
+			body: `
+case "$1" in
+dump-config)
+	printf '%s\n' '{"diff":{"pager":"delta"}}'
+	;;
+*)
+	echo "unexpected command: $*" >&2
+	exit 1
+	;;
+esac
+`,
 			wantPager: "delta",
 		},
 		{
-			name:      "pager with args",
-			input:     `{"diff":{"pager":"delta --syntax-theme=Nord"}}`,
-			wantPager: "delta --syntax-theme=Nord",
+			name: "pager with quoted args",
+			body: `
+case "$1" in
+dump-config)
+	printf '%s\n' '{"diff":{"pager":"delta --syntax-theme=\"GitHub Dark\""}}'
+	;;
+*)
+	echo "unexpected command: $*" >&2
+	exit 1
+	;;
+esac
+`,
+			wantPager: `delta --syntax-theme="GitHub Dark"`,
 		},
 		{
-			name:      "pager empty",
-			input:     `{"diff":{"pager":""}}`,
+			name: "diff section missing",
+			body: `
+case "$1" in
+dump-config)
+	printf '%s\n' '{"color":{"ui":true}}'
+	;;
+*)
+	echo "unexpected command: $*" >&2
+	exit 1
+	;;
+esac
+`,
 			wantPager: "",
 		},
 		{
-			name:      "diff section missing",
-			input:     `{"color":{"ui":true}}`,
-			wantPager: "",
+			name: "invalid json",
+			body: `
+case "$1" in
+dump-config)
+	printf '%s\n' 'not json'
+	;;
+*)
+	echo "unexpected command: $*" >&2
+	exit 1
+	;;
+esac
+`,
+			wantErr: "invalid character",
 		},
 		{
-			name:      "empty object",
-			input:     `{}`,
-			wantPager: "",
-		},
-		{
-			name:    "invalid json",
-			input:   `not json`,
-			wantErr: true,
+			name: "dump-config command failure",
+			body: `
+case "$1" in
+dump-config)
+	echo "dump-config failed" >&2
+	exit 1
+	;;
+*)
+	echo "unexpected command: $*" >&2
+	exit 1
+	;;
+esac
+`,
+			wantErr: "chezmoi dump-config: dump-config failed",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var cfg struct {
-				Diff struct {
-					Pager string `json:"pager"`
-				} `json:"diff"`
-			}
-			err := json.Unmarshal([]byte(tt.input), &cfg)
-			if tt.wantErr {
+			client := New(WithBinaryPath(writeFakeChezmoiClientBinary(t, tt.body)))
+
+			cfg, err := client.DiffConfig()
+			if tt.wantErr != "" {
 				if err == nil {
 					t.Fatal("expected error, got nil")
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("error = %q, want substring %q", err.Error(), tt.wantErr)
 				}
 				return
 			}
 			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
+				t.Fatalf("DiffConfig returned unexpected error: %v", err)
 			}
-			if cfg.Diff.Pager != tt.wantPager {
-				t.Errorf("pager = %q, want %q", cfg.Diff.Pager, tt.wantPager)
+			if cfg.Pager != tt.wantPager {
+				t.Fatalf("Pager = %q, want %q", cfg.Pager, tt.wantPager)
 			}
 		})
 	}

--- a/internal/chezmoi/diffpager_test.go
+++ b/internal/chezmoi/diffpager_test.go
@@ -1,0 +1,69 @@
+package chezmoi
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestParseDiffConfig(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		wantPager string
+		wantErr   bool
+	}{
+		{
+			name:      "pager set",
+			input:     `{"diff":{"pager":"delta"}}`,
+			wantPager: "delta",
+		},
+		{
+			name:      "pager with args",
+			input:     `{"diff":{"pager":"delta --syntax-theme=Nord"}}`,
+			wantPager: "delta --syntax-theme=Nord",
+		},
+		{
+			name:      "pager empty",
+			input:     `{"diff":{"pager":""}}`,
+			wantPager: "",
+		},
+		{
+			name:      "diff section missing",
+			input:     `{"color":{"ui":true}}`,
+			wantPager: "",
+		},
+		{
+			name:      "empty object",
+			input:     `{}`,
+			wantPager: "",
+		},
+		{
+			name:    "invalid json",
+			input:   `not json`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var cfg struct {
+				Diff struct {
+					Pager string `json:"pager"`
+				} `json:"diff"`
+			}
+			err := json.Unmarshal([]byte(tt.input), &cfg)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if cfg.Diff.Pager != tt.wantPager {
+				t.Errorf("pager = %q, want %q", cfg.Diff.Pager, tt.wantPager)
+			}
+		})
+	}
+}

--- a/internal/chezmoi/service.go
+++ b/internal/chezmoi/service.go
@@ -55,6 +55,7 @@ func (s *Service) CatTarget(path string) (string, error) { return s.client.CatTa
 func (s *Service) CatConfig() (string, error)            { return s.client.CatConfig() }
 func (s *Service) DumpConfig() (string, error)           { return s.client.DumpConfig() }
 func (s *Service) DumpConfigJSON() (string, error)       { return s.client.DumpConfigJSON() }
+func (s *Service) DiffConfig() (DiffConfig, error)       { return s.client.DiffConfig() }
 func (s *Service) Data() (string, error)                 { return s.client.Data() }
 func (s *Service) DataJSON() (string, error)             { return s.client.DataJSON() }
 func (s *Service) Doctor() (string, error)               { return s.client.Doctor() }

--- a/internal/tui/commands_exec.go
+++ b/internal/tui/commands_exec.go
@@ -19,7 +19,11 @@ func (m Model) executeChezmoiCommand(id chezmoiCommandID) (tea.Model, tea.Cmd) {
 		m.diff.previewApply = true
 		return m, func() tea.Msg {
 			output, err := m.service.DiffAll()
-			return chezmoiSourceContentMsg{path: "Preview: chezmoi apply", content: output, err: err}
+			if err != nil {
+				return chezmoiSourceContentMsg{path: "Preview: chezmoi apply", content: output, err: err}
+			}
+			rendered, ok := m.renderDiffWithPager(output)
+			return chezmoiSourceContentMsg{path: "Preview: chezmoi apply", content: output, renderedDiff: rendered, pagerApplied: ok}
 		}
 	case chezmoiCmdUpdate:
 		m.view = ConfirmScreen
@@ -55,7 +59,11 @@ func (m Model) executeChezmoiCommand(id chezmoiCommandID) (tea.Model, tea.Cmd) {
 		m.ui.busyAction = true
 		return m, func() tea.Msg {
 			output, err := m.service.DiffAll()
-			return chezmoiSourceContentMsg{path: "chezmoi diff", content: output, err: err}
+			if err != nil {
+				return chezmoiSourceContentMsg{path: "chezmoi diff", content: output, err: err}
+			}
+			rendered, ok := m.renderDiffWithPager(output)
+			return chezmoiSourceContentMsg{path: "chezmoi diff", content: output, renderedDiff: rendered, pagerApplied: ok}
 		}
 	case chezmoiCmdCatConfig:
 		m.ui.busyAction = true

--- a/internal/tui/diff.go
+++ b/internal/tui/diff.go
@@ -9,13 +9,18 @@ import (
 
 // preRenderDiffContent renders all diff lines into a single styled string
 // suitable for viewport.SetContent(). The viewport handles scroll/visibility.
-func preRenderDiffContent(lines []string, width int) string {
+// When pagerApplied is true, lines already contain ANSI colors from an external
+// pager and are rendered as-is with only truncation/padding.
+func preRenderDiffContent(lines []string, width int, pagerApplied bool) string {
 	var b strings.Builder
 	for i, line := range lines {
-		style := diffLineStyle(line)
-		rendered := style.Render(visualTruncate(line, width-2))
 		b.WriteString("  ")
-		b.WriteString(rendered)
+		if pagerApplied {
+			b.WriteString(visualTruncate(line, width-2))
+		} else {
+			style := diffLineStyle(line)
+			b.WriteString(style.Render(visualTruncate(line, width-2)))
+		}
 		if i < len(lines)-1 {
 			b.WriteString("\n")
 		}

--- a/internal/tui/diff.go
+++ b/internal/tui/diff.go
@@ -10,7 +10,7 @@ import (
 // preRenderDiffContent renders all diff lines into a single styled string
 // suitable for viewport.SetContent(). The viewport handles scroll/visibility.
 // When pagerApplied is true, lines already contain ANSI colors from an external
-// pager and are rendered as-is with only truncation/padding.
+// pager and are passed through as-is; the viewport's SoftWrap handles wrapping.
 func preRenderDiffContent(lines []string, width int, pagerApplied bool) string {
 	var b strings.Builder
 	for i, line := range lines {

--- a/internal/tui/diff.go
+++ b/internal/tui/diff.go
@@ -14,10 +14,10 @@ import (
 func preRenderDiffContent(lines []string, width int, pagerApplied bool) string {
 	var b strings.Builder
 	for i, line := range lines {
-		b.WriteString("  ")
 		if pagerApplied {
-			b.WriteString(visualTruncate(line, width-2))
+			b.WriteString(line)
 		} else {
+			b.WriteString("  ")
 			style := diffLineStyle(line)
 			b.WriteString(style.Render(visualTruncate(line, width-2)))
 		}

--- a/internal/tui/diffpager.go
+++ b/internal/tui/diffpager.go
@@ -34,8 +34,8 @@ func preparePagerArgs(pagerCmd string, isDark bool) ([]string, bool) {
 		return nil, false
 	}
 
-	parts := strings.Fields(pagerCmd)
-	if len(parts) == 0 {
+	parts, err := splitCommandLine(pagerCmd)
+	if err != nil || len(parts) == 0 {
 		return nil, false
 	}
 
@@ -58,6 +58,78 @@ func preparePagerArgs(pagerCmd string, isDark bool) ([]string, bool) {
 	}
 
 	return args, true
+}
+
+// splitCommandLine parses a shell-like argv string, supporting quoted args
+// and backslash escapes. It intentionally does not implement full shell
+// expansion semantics.
+func splitCommandLine(input string) ([]string, error) {
+	var (
+		args          []string
+		current       strings.Builder
+		inSingleQuote bool
+		inDoubleQuote bool
+	)
+
+	flushCurrent := func() {
+		if current.Len() == 0 {
+			return
+		}
+		args = append(args, current.String())
+		current.Reset()
+	}
+
+	for i := 0; i < len(input); i++ {
+		ch := input[i]
+
+		switch {
+		case inSingleQuote:
+			if ch == '\'' {
+				inSingleQuote = false
+				continue
+			}
+			current.WriteByte(ch)
+
+		case inDoubleQuote:
+			switch ch {
+			case '"':
+				inDoubleQuote = false
+			case '\\':
+				i++
+				if i >= len(input) {
+					return nil, errors.New("unterminated escape sequence")
+				}
+				current.WriteByte(input[i])
+			default:
+				current.WriteByte(ch)
+			}
+
+		default:
+			switch ch {
+			case ' ', '\t', '\n', '\r':
+				flushCurrent()
+			case '\'':
+				inSingleQuote = true
+			case '"':
+				inDoubleQuote = true
+			case '\\':
+				i++
+				if i >= len(input) {
+					return nil, errors.New("unterminated escape sequence")
+				}
+				current.WriteByte(input[i])
+			default:
+				current.WriteByte(ch)
+			}
+		}
+	}
+
+	if inSingleQuote || inDoubleQuote {
+		return nil, errors.New("unterminated quoted string")
+	}
+
+	flushCurrent()
+	return args, nil
 }
 
 // pipeThroughDiffPager runs rawDiff through the pager command and returns

--- a/internal/tui/diffpager.go
+++ b/internal/tui/diffpager.go
@@ -1,0 +1,114 @@
+package tui
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+var errPagerUnsupported = errors.New("pager not in supported list")
+
+// pagerTimeout is the maximum time allowed for a pager subprocess.
+const pagerTimeout = 3 * time.Second
+
+// supportedPagerFlags maps pager binary basenames to mandatory safety flags.
+// Only pagers in this table are activated; unsupported pagers are ignored.
+var supportedPagerFlags = map[string][]string{
+	"delta": {
+		"--color-only",
+		"--paging=never",
+		"--detect-dark-light=never",
+		"--width=variable",
+		"--line-numbers=false",
+		"--side-by-side=false",
+	},
+	"bat":           {"--paging=never", "--plain", "--color=always"},
+	"diff-so-fancy": {},
+}
+
+// preparePagerArgs parses the user's pager command string, checks if the
+// binary is supported, and appends safety flags. Returns the args slice
+// and true if the pager is supported, or nil and false otherwise.
+func preparePagerArgs(pagerCmd string, isDark bool) ([]string, bool) {
+	if pagerCmd == "" {
+		return nil, false
+	}
+
+	parts := strings.Fields(pagerCmd)
+	if len(parts) == 0 {
+		return nil, false
+	}
+
+	binary := filepath.Base(parts[0])
+	flags, supported := supportedPagerFlags[binary]
+	if !supported {
+		return nil, false
+	}
+
+	args := make([]string, len(parts), len(parts)+len(flags)+1)
+	copy(args, parts)
+	args = append(args, flags...)
+
+	if binary == "delta" {
+		if isDark {
+			args = append(args, "--dark")
+		} else {
+			args = append(args, "--light")
+		}
+	}
+
+	return args, true
+}
+
+// pipeThroughDiffPager runs rawDiff through the pager command and returns
+// ANSI-colored output. Returns an error if the pager is unsupported, not
+// installed, or fails.
+func pipeThroughDiffPager(rawDiff, pagerCmd string, isDark bool) (string, error) {
+	args, supported := preparePagerArgs(pagerCmd, isDark)
+	if !supported {
+		return "", errPagerUnsupported
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), pagerTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, args[0], args[1:]...) //#nosec G204 -- user-configured pager from chezmoi config
+	cmd.Stdin = strings.NewReader(rawDiff)
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+
+	return stdout.String(), nil
+}
+
+// diffRawLines returns the canonical raw diff lines for semantic operations
+// like diffSummary. Falls back to rendered lines if rawLines is empty.
+func (m Model) diffRawLines() []string {
+	if len(m.diff.rawLines) > 0 {
+		return m.diff.rawLines
+	}
+	return m.diff.lines
+}
+
+// renderDiffWithPager attempts to pipe rawDiff through the configured pager.
+// Returns the rendered output and true if successful, or empty string and false
+// if no pager is configured, unsupported, or execution fails.
+func (m Model) renderDiffWithPager(rawDiff string) (string, bool) {
+	if m.diffPagerCmd == "" {
+		return "", false
+	}
+	rendered, err := pipeThroughDiffPager(rawDiff, m.diffPagerCmd, activeTheme.IsDark)
+	if err != nil {
+		return "", false
+	}
+	return rendered, true
+}

--- a/internal/tui/diffpager.go
+++ b/internal/tui/diffpager.go
@@ -19,10 +19,8 @@ const pagerTimeout = 3 * time.Second
 // Only pagers in this table are activated; unsupported pagers are ignored.
 var supportedPagerFlags = map[string][]string{
 	"delta": {
-		"--color-only",
 		"--paging=never",
 		"--detect-dark-light=never",
-		"--width=variable",
 	},
 	"bat":           {"--paging=never", "--plain", "--color=always"},
 	"diff-so-fancy": {},

--- a/internal/tui/diffpager.go
+++ b/internal/tui/diffpager.go
@@ -20,6 +20,9 @@ const pagerTimeout = 3 * time.Second
 var supportedPagerFlags = map[string][]string{
 	"delta": {
 		"--paging=never",
+		// Delta runs in a subprocess that cannot reliably infer the same theme
+		// Bubble Tea already selected, so disable auto-detection and pass
+		// --dark/--light explicitly below.
 		"--detect-dark-light=never",
 	},
 	"bat":           {"--paging=never", "--plain", "--color=always"},
@@ -135,10 +138,10 @@ func splitCommandLine(input string) ([]string, error) {
 // pipeThroughDiffPager runs rawDiff through the pager command and returns
 // ANSI-colored output. Returns an error if the pager is unsupported, not
 // installed, or fails.
-func pipeThroughDiffPager(rawDiff, pagerCmd string, isDark bool) (string, error) {
+func pipeThroughDiffPager(rawDiff, pagerCmd string, isDark bool) (string, string, error) {
 	args, supported := preparePagerArgs(pagerCmd, isDark)
 	if !supported {
-		return "", errPagerUnsupported
+		return "", "", errPagerUnsupported
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), pagerTimeout)
@@ -152,10 +155,10 @@ func pipeThroughDiffPager(rawDiff, pagerCmd string, isDark bool) (string, error)
 	cmd.Stderr = &stderr
 
 	if err := cmd.Run(); err != nil {
-		return "", err
+		return "", stderr.String(), err
 	}
 
-	return stdout.String(), nil
+	return stdout.String(), stderr.String(), nil
 }
 
 // diffRawLines returns the canonical raw diff lines for semantic operations
@@ -174,8 +177,15 @@ func (m Model) renderDiffWithPager(rawDiff string) (string, bool) {
 	if m.diffPagerCmd == "" {
 		return "", false
 	}
-	rendered, err := pipeThroughDiffPager(rawDiff, m.diffPagerCmd, activeTheme.IsDark)
+	rendered, stderr, err := pipeThroughDiffPager(rawDiff, m.diffPagerCmd, activeTheme.IsDark)
 	if err != nil {
+		if m.debugLog != nil {
+			args := []any{"pager", m.diffPagerCmd, "err", err}
+			if trimmed := strings.TrimSpace(stderr); trimmed != "" {
+				args = append(args, "stderr", trimmed)
+			}
+			m.debugLog.Warn("diff pager failed", args...)
+		}
 		return "", false
 	}
 	return rendered, true

--- a/internal/tui/diffpager.go
+++ b/internal/tui/diffpager.go
@@ -23,8 +23,6 @@ var supportedPagerFlags = map[string][]string{
 		"--paging=never",
 		"--detect-dark-light=never",
 		"--width=variable",
-		"--line-numbers=false",
-		"--side-by-side=false",
 	},
 	"bat":           {"--paging=never", "--plain", "--color=always"},
 	"diff-so-fancy": {},

--- a/internal/tui/diffpager_integration_test.go
+++ b/internal/tui/diffpager_integration_test.go
@@ -1,0 +1,262 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+)
+
+// --- Full-screen diff state tests ---
+
+func TestDiffLoaded_WithPager_StoresRawAndRenderedLines(t *testing.T) {
+	m := newTestModel()
+	m.diffPagerCmd = "delta" // not actually invoked in this test
+
+	raw := "+added\n-removed\n context"
+	rendered := "\x1b[32m+added\x1b[0m\n\x1b[31m-removed\x1b[0m\n context"
+
+	msg := chezmoiDiffLoadedMsg{
+		path:         "test.txt",
+		diff:         raw,
+		renderedDiff: rendered,
+		pagerApplied: true,
+	}
+
+	m, _ = sendMsg(t, m, msg)
+
+	if m.view != DiffScreen {
+		t.Fatalf("view = %d, want DiffScreen", m.view)
+	}
+	if !m.diff.pagerApplied {
+		t.Fatal("pagerApplied should be true")
+	}
+	// rawLines should be from raw diff
+	wantRaw := strings.Split(raw, "\n")
+	if len(m.diff.rawLines) != len(wantRaw) {
+		t.Fatalf("rawLines len = %d, want %d", len(m.diff.rawLines), len(wantRaw))
+	}
+	// lines should be from rendered diff
+	wantRendered := strings.Split(rendered, "\n")
+	if len(m.diff.lines) != len(wantRendered) {
+		t.Fatalf("lines len = %d, want %d", len(m.diff.lines), len(wantRendered))
+	}
+	if m.diff.lines[0] == m.diff.rawLines[0] {
+		t.Fatal("lines[0] should differ from rawLines[0] when pager is applied")
+	}
+}
+
+func TestDiffLoaded_WithoutPager_LinesEqualRawLines(t *testing.T) {
+	m := newTestModel()
+
+	raw := "+added\n-removed\n context"
+	msg := chezmoiDiffLoadedMsg{
+		path:         "test.txt",
+		diff:         raw,
+		pagerApplied: false,
+	}
+
+	m, _ = sendMsg(t, m, msg)
+
+	if m.diff.pagerApplied {
+		t.Fatal("pagerApplied should be false")
+	}
+	// lines and rawLines should be the same slice
+	if len(m.diff.lines) != len(m.diff.rawLines) {
+		t.Fatalf("lines len = %d, rawLines len = %d, should match", len(m.diff.lines), len(m.diff.rawLines))
+	}
+}
+
+func TestDiffSummary_UsesRawLines_WhenPagerActive(t *testing.T) {
+	m := newTestModel()
+	m.diff.rawLines = []string{"+added", "-removed", " context"}
+	m.diff.lines = []string{"\x1b[32madded\x1b[0m", "\x1b[31mremoved\x1b[0m", " context"}
+	m.diff.pagerApplied = true
+
+	summary := diffSummary(m.diffRawLines())
+
+	if !strings.Contains(summary, "+1") || !strings.Contains(summary, "-1") {
+		t.Fatalf("summary = %q, expected +1/-1", summary)
+	}
+}
+
+func TestDiffSummary_UsesLines_WhenNoPager(t *testing.T) {
+	m := newTestModel()
+	m.diff.rawLines = nil
+	m.diff.lines = []string{"+added", "-removed", " context"}
+	m.diff.pagerApplied = false
+
+	summary := diffSummary(m.diffRawLines())
+
+	if !strings.Contains(summary, "+1") || !strings.Contains(summary, "-1") {
+		t.Fatalf("summary = %q, expected +1/-1", summary)
+	}
+}
+
+// --- Panel cache tests ---
+
+func TestPanelCache_StoresRawAndRenderedLines(t *testing.T) {
+	raw := "+added\n-removed"
+	rendered := "\x1b[32m+added\x1b[0m\n\x1b[31m-removed\x1b[0m"
+
+	msg := panelContentLoadedMsg{
+		path:         "test.txt",
+		mode:         panelModeDiff,
+		section:      changesSectionDrift,
+		content:      raw,
+		rendered:     rendered,
+		pagerApplied: true,
+	}
+
+	m := newTestModel()
+	m.diffPagerCmd = "delta"
+	m.panel.currentPath = "test.txt"
+	m.panel.currentSection = changesSectionDrift
+	m.panel.contentMode = panelModeDiff
+
+	m, _ = sendMsg(t, m, msg)
+
+	entry, ok := m.panel.cacheGet("test.txt", panelModeDiff, changesSectionDrift)
+	if !ok {
+		t.Fatal("expected cache entry")
+	}
+	if !entry.pagerApplied {
+		t.Fatal("pagerApplied should be true in cache entry")
+	}
+	if entry.rawLines == nil {
+		t.Fatal("rawLines should not be nil for diff mode")
+	}
+
+	// rawLines should be from raw content
+	wantRaw := strings.Split(raw, "\n")
+	if len(entry.rawLines) != len(wantRaw) {
+		t.Fatalf("rawLines len = %d, want %d", len(entry.rawLines), len(wantRaw))
+	}
+
+	// lines should be from rendered content
+	wantRendered := strings.Split(rendered, "\n")
+	if len(entry.lines) != len(wantRendered) {
+		t.Fatalf("lines len = %d, want %d", len(entry.lines), len(wantRendered))
+	}
+}
+
+func TestPanelCache_NonDiff_NoRawLines(t *testing.T) {
+	msg := panelContentLoadedMsg{
+		path:    "test.txt",
+		mode:    panelModeContent,
+		section: changesSectionDrift,
+		content: "file content here",
+	}
+
+	m := newTestModel()
+	m.panel.currentPath = "test.txt"
+	m.panel.currentSection = changesSectionDrift
+	m.panel.contentMode = panelModeContent
+
+	m, _ = sendMsg(t, m, msg)
+
+	entry, ok := m.panel.cacheGet("test.txt", panelModeContent, changesSectionDrift)
+	if !ok {
+		t.Fatal("expected cache entry")
+	}
+	if entry.rawLines != nil {
+		t.Fatal("rawLines should be nil for non-diff content")
+	}
+	if entry.pagerApplied {
+		t.Fatal("pagerApplied should be false for non-diff content")
+	}
+}
+
+// --- Reset/cleanup tests ---
+
+func TestDiffClear_ResetsAllPagerFields(t *testing.T) {
+	var d diffViewState
+	d.content = "diff content"
+	d.lines = []string{"+added"}
+	d.rawLines = []string{"+added"}
+	d.pagerApplied = true
+	d.viewportReady = true
+
+	d.clear()
+
+	if d.content != "" {
+		t.Fatal("content should be empty after clear")
+	}
+	if d.lines != nil {
+		t.Fatal("lines should be nil after clear")
+	}
+	if d.rawLines != nil {
+		t.Fatal("rawLines should be nil after clear")
+	}
+	if d.pagerApplied {
+		t.Fatal("pagerApplied should be false after clear")
+	}
+	if d.viewportReady {
+		t.Fatal("viewportReady should be false after clear")
+	}
+}
+
+// --- Builtin fallback tests ---
+
+func TestDiffLoaded_PagerFailed_FallsBackToBuiltin(t *testing.T) {
+	m := newTestModel()
+	m.diffPagerCmd = "delta" // configured but pager "failed"
+
+	raw := "+added\n-removed"
+	msg := chezmoiDiffLoadedMsg{
+		path:         "test.txt",
+		diff:         raw,
+		pagerApplied: false, // pager invocation failed
+	}
+
+	m, _ = sendMsg(t, m, msg)
+
+	if m.diff.pagerApplied {
+		t.Fatal("pagerApplied should be false when pager fails")
+	}
+	// lines should equal rawLines (builtin fallback)
+	if len(m.diff.lines) != len(m.diff.rawLines) {
+		t.Fatal("lines and rawLines should match on fallback")
+	}
+}
+
+// --- Source content (apply preview) tests ---
+
+func TestSourceContent_WithPager_StoresPagerOutput(t *testing.T) {
+	m := newTestModel()
+	m.diffPagerCmd = "delta"
+	m.diff.previewApply = true
+
+	raw := "+added\n-removed"
+	rendered := "\x1b[32m+added\x1b[0m\n\x1b[31m-removed\x1b[0m"
+
+	msg := chezmoiSourceContentMsg{
+		path:         "Preview: chezmoi apply",
+		content:      raw,
+		renderedDiff: rendered,
+		pagerApplied: true,
+	}
+
+	m, _ = sendMsg(t, m, msg)
+
+	if !m.diff.pagerApplied {
+		t.Fatal("pagerApplied should be true")
+	}
+	if len(m.diff.rawLines) != 2 {
+		t.Fatalf("rawLines len = %d, want 2", len(m.diff.rawLines))
+	}
+}
+
+func TestSourceContent_NonDiff_NoPager(t *testing.T) {
+	m := newTestModel()
+	m.diffPagerCmd = "delta"
+
+	msg := chezmoiSourceContentMsg{
+		path:    "chezmoi doctor",
+		content: "doctor output",
+	}
+
+	m, _ = sendMsg(t, m, msg)
+
+	if m.diff.pagerApplied {
+		t.Fatal("pagerApplied should be false for non-diff content")
+	}
+}

--- a/internal/tui/diffpager_test.go
+++ b/internal/tui/diffpager_test.go
@@ -1,6 +1,8 @@
 package tui
 
 import (
+	"bytes"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -103,14 +105,14 @@ func TestPreparePagerArgs(t *testing.T) {
 }
 
 func TestPipeThroughDiffPager_Unsupported(t *testing.T) {
-	_, err := pipeThroughDiffPager("diff content", "less", true)
+	_, _, err := pipeThroughDiffPager("diff content", "less", true)
 	if err == nil {
 		t.Fatal("expected error for unsupported pager")
 	}
 }
 
 func TestPipeThroughDiffPager_Empty(t *testing.T) {
-	_, err := pipeThroughDiffPager("diff content", "", true)
+	_, _, err := pipeThroughDiffPager("diff content", "", true)
 	if err == nil {
 		t.Fatal("expected error for empty pager command")
 	}
@@ -128,7 +130,7 @@ func TestPipeThroughDiffPager_SupportedPager(t *testing.T) {
 		t.Fatalf("write fake pager: %v", err)
 	}
 
-	rendered, err := pipeThroughDiffPager("+added\n-removed\n", scriptPath+` --syntax-theme="GitHub Dark"`, true)
+	rendered, _, err := pipeThroughDiffPager("+added\n-removed\n", scriptPath+` --syntax-theme="GitHub Dark"`, true)
 	if err != nil {
 		t.Fatalf("pipeThroughDiffPager returned error: %v", err)
 	}
@@ -138,5 +140,39 @@ func TestPipeThroughDiffPager_SupportedPager(t *testing.T) {
 	}
 	if !strings.Contains(rendered, "+added\n-removed") {
 		t.Fatalf("rendered output missing piped diff content, got: %q", rendered)
+	}
+}
+
+func TestRenderDiffWithPager_LogsPagerStderr(t *testing.T) {
+	dir := t.TempDir()
+	scriptPath := filepath.Join(dir, "delta")
+	script := strings.Join([]string{
+		"#!/bin/sh",
+		`echo "delta failed to parse input" >&2`,
+		"exit 1",
+	}, "\n") + "\n"
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake pager: %v", err)
+	}
+
+	var logOutput bytes.Buffer
+	m := newTestModel()
+	m.diffPagerCmd = scriptPath
+	m.debugLog = slog.New(slog.NewJSONHandler(&logOutput, nil))
+
+	rendered, ok := m.renderDiffWithPager("+added\n")
+	if ok {
+		t.Fatal("renderDiffWithPager should fall back when pager execution fails")
+	}
+	if rendered != "" {
+		t.Fatalf("rendered = %q, want empty string", rendered)
+	}
+
+	logged := logOutput.String()
+	if !strings.Contains(logged, `"msg":"diff pager failed"`) {
+		t.Fatalf("expected diff pager failure log, got: %q", logged)
+	}
+	if !strings.Contains(logged, `"stderr":"delta failed to parse input"`) {
+		t.Fatalf("expected pager stderr in log output, got: %q", logged)
 	}
 }

--- a/internal/tui/diffpager_test.go
+++ b/internal/tui/diffpager_test.go
@@ -1,7 +1,10 @@
 package tui
 
 import (
+	"os"
+	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -46,6 +49,17 @@ func TestPreparePagerArgs(t *testing.T) {
 			wantOk: true,
 		},
 		{
+			name:     "delta with quoted arg containing spaces",
+			pagerCmd: `delta --syntax-theme="GitHub Dark"`,
+			isDark:   true,
+			wantArgs: []string{
+				"delta", "--syntax-theme=GitHub Dark",
+				"--paging=never", "--detect-dark-light=never",
+				"--dark",
+			},
+			wantOk: true,
+		},
+		{
 			name:     "delta absolute path",
 			pagerCmd: "/usr/local/bin/delta",
 			isDark:   true,
@@ -67,6 +81,11 @@ func TestPreparePagerArgs(t *testing.T) {
 			pagerCmd: "diff-so-fancy",
 			wantArgs: []string{"diff-so-fancy"},
 			wantOk:   true,
+		},
+		{
+			name:     "unterminated quote",
+			pagerCmd: `delta --syntax-theme="GitHub Dark`,
+			wantOk:   false,
 		},
 	}
 
@@ -94,5 +113,30 @@ func TestPipeThroughDiffPager_Empty(t *testing.T) {
 	_, err := pipeThroughDiffPager("diff content", "", true)
 	if err == nil {
 		t.Fatal("expected error for empty pager command")
+	}
+}
+
+func TestPipeThroughDiffPager_SupportedPager(t *testing.T) {
+	dir := t.TempDir()
+	scriptPath := filepath.Join(dir, "delta")
+	script := strings.Join([]string{
+		"#!/bin/sh",
+		`printf 'ARGS:%s\n' "$*"`,
+		"cat",
+	}, "\n") + "\n"
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake pager: %v", err)
+	}
+
+	rendered, err := pipeThroughDiffPager("+added\n-removed\n", scriptPath+` --syntax-theme="GitHub Dark"`, true)
+	if err != nil {
+		t.Fatalf("pipeThroughDiffPager returned error: %v", err)
+	}
+
+	if !strings.Contains(rendered, "ARGS:--syntax-theme=GitHub Dark --paging=never --detect-dark-light=never --dark") {
+		t.Fatalf("rendered output missing expected args, got: %q", rendered)
+	}
+	if !strings.Contains(rendered, "+added\n-removed") {
+		t.Fatalf("rendered output missing piped diff content, got: %q", rendered)
 	}
 }

--- a/internal/tui/diffpager_test.go
+++ b/internal/tui/diffpager_test.go
@@ -1,0 +1,101 @@
+package tui
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestPreparePagerArgs(t *testing.T) {
+	tests := []struct {
+		name     string
+		pagerCmd string
+		isDark   bool
+		wantArgs []string
+		wantOk   bool
+	}{
+		{
+			name:     "empty pager",
+			pagerCmd: "",
+			wantOk:   false,
+		},
+		{
+			name:     "unsupported pager",
+			pagerCmd: "less",
+			wantOk:   false,
+		},
+		{
+			name:     "delta bare dark",
+			pagerCmd: "delta",
+			isDark:   true,
+			wantArgs: []string{
+				"delta",
+				"--color-only", "--paging=never", "--detect-dark-light=never",
+				"--width=variable", "--line-numbers=false", "--side-by-side=false",
+				"--dark",
+			},
+			wantOk: true,
+		},
+		{
+			name:     "delta with user args light",
+			pagerCmd: "delta --syntax-theme=Nord",
+			isDark:   false,
+			wantArgs: []string{
+				"delta", "--syntax-theme=Nord",
+				"--color-only", "--paging=never", "--detect-dark-light=never",
+				"--width=variable", "--line-numbers=false", "--side-by-side=false",
+				"--light",
+			},
+			wantOk: true,
+		},
+		{
+			name:     "delta absolute path",
+			pagerCmd: "/usr/local/bin/delta",
+			isDark:   true,
+			wantArgs: []string{
+				"/usr/local/bin/delta",
+				"--color-only", "--paging=never", "--detect-dark-light=never",
+				"--width=variable", "--line-numbers=false", "--side-by-side=false",
+				"--dark",
+			},
+			wantOk: true,
+		},
+		{
+			name:     "bat",
+			pagerCmd: "bat",
+			wantArgs: []string{"bat", "--paging=never", "--plain", "--color=always"},
+			wantOk:   true,
+		},
+		{
+			name:     "diff-so-fancy no extra flags",
+			pagerCmd: "diff-so-fancy",
+			wantArgs: []string{"diff-so-fancy"},
+			wantOk:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			args, ok := preparePagerArgs(tt.pagerCmd, tt.isDark)
+			if ok != tt.wantOk {
+				t.Fatalf("ok = %v, want %v", ok, tt.wantOk)
+			}
+			if tt.wantOk && !reflect.DeepEqual(args, tt.wantArgs) {
+				t.Errorf("args = %v, want %v", args, tt.wantArgs)
+			}
+		})
+	}
+}
+
+func TestPipeThroughDiffPager_Unsupported(t *testing.T) {
+	_, err := pipeThroughDiffPager("diff content", "less", true)
+	if err == nil {
+		t.Fatal("expected error for unsupported pager")
+	}
+}
+
+func TestPipeThroughDiffPager_Empty(t *testing.T) {
+	_, err := pipeThroughDiffPager("diff content", "", true)
+	if err == nil {
+		t.Fatal("expected error for empty pager command")
+	}
+}

--- a/internal/tui/diffpager_test.go
+++ b/internal/tui/diffpager_test.go
@@ -30,7 +30,7 @@ func TestPreparePagerArgs(t *testing.T) {
 			wantArgs: []string{
 				"delta",
 				"--color-only", "--paging=never", "--detect-dark-light=never",
-				"--width=variable", "--line-numbers=false", "--side-by-side=false",
+				"--width=variable",
 				"--dark",
 			},
 			wantOk: true,
@@ -42,7 +42,7 @@ func TestPreparePagerArgs(t *testing.T) {
 			wantArgs: []string{
 				"delta", "--syntax-theme=Nord",
 				"--color-only", "--paging=never", "--detect-dark-light=never",
-				"--width=variable", "--line-numbers=false", "--side-by-side=false",
+				"--width=variable",
 				"--light",
 			},
 			wantOk: true,
@@ -54,7 +54,7 @@ func TestPreparePagerArgs(t *testing.T) {
 			wantArgs: []string{
 				"/usr/local/bin/delta",
 				"--color-only", "--paging=never", "--detect-dark-light=never",
-				"--width=variable", "--line-numbers=false", "--side-by-side=false",
+				"--width=variable",
 				"--dark",
 			},
 			wantOk: true,

--- a/internal/tui/diffpager_test.go
+++ b/internal/tui/diffpager_test.go
@@ -29,8 +29,7 @@ func TestPreparePagerArgs(t *testing.T) {
 			isDark:   true,
 			wantArgs: []string{
 				"delta",
-				"--color-only", "--paging=never", "--detect-dark-light=never",
-				"--width=variable",
+				"--paging=never", "--detect-dark-light=never",
 				"--dark",
 			},
 			wantOk: true,
@@ -41,8 +40,7 @@ func TestPreparePagerArgs(t *testing.T) {
 			isDark:   false,
 			wantArgs: []string{
 				"delta", "--syntax-theme=Nord",
-				"--color-only", "--paging=never", "--detect-dark-light=never",
-				"--width=variable",
+				"--paging=never", "--detect-dark-light=never",
 				"--light",
 			},
 			wantOk: true,
@@ -53,8 +51,7 @@ func TestPreparePagerArgs(t *testing.T) {
 			isDark:   true,
 			wantArgs: []string{
 				"/usr/local/bin/delta",
-				"--color-only", "--paging=never", "--detect-dark-light=never",
-				"--width=variable",
+				"--paging=never", "--detect-dark-light=never",
 				"--dark",
 			},
 			wantOk: true,

--- a/internal/tui/golden_test.go
+++ b/internal/tui/golden_test.go
@@ -134,6 +134,24 @@ func TestGoldenDiffView(t *testing.T) {
 		output := stripForGolden(m.renderDiffView())
 		golden.RequireEqual(t, []byte(output))
 	})
+
+	t.Run("pager_mode", func(t *testing.T) {
+		rawDiff := "--- a/.bashrc\n+++ b/.bashrc\n@@ -1,3 +1,4 @@\n export EDITOR=vim\n+export PAGER=less\n alias ll='ls -la'\n"
+		rawLines := strings.Split(strings.TrimRight(rawDiff, "\n"), "\n")
+		pagerLines := []string{
+			".bashrc │ 1 +",
+			" 1 │ export EDITOR=vim",
+			" 2 │ export PAGER=less",
+		}
+		m := newTestModel(
+			WithDiffContent("/home/test/.bashrc", rawDiff, len(rawLines)),
+		)
+		m.diff.rawLines = rawLines
+		m.diff.lines = pagerLines
+		m.diff.pagerApplied = true
+		output := stripForGolden(m.renderDiffView())
+		golden.RequireEqual(t, []byte(output))
+	})
 }
 
 // ── Landing View ────────────────────────────────────────────────────
@@ -163,6 +181,30 @@ func TestGoldenPanel(t *testing.T) {
 		m.panel.cachePut("/home/test/.bashrc", panelModeDiff, changesSectionDrift, panelCacheEntry{
 			content: "+added line\n-removed line",
 			lines:   []string{"+added line", "-removed line"},
+		})
+		output := stripForGolden(m.renderFilePanel(panelWidth))
+		golden.RequireEqual(t, []byte(output))
+	})
+
+	t.Run("diff_mode_pager", func(t *testing.T) {
+		rawDiff := "--- a/.bashrc\n+++ b/.bashrc\n@@ -1,3 +1,4 @@\n export EDITOR=vim\n+export PAGER=less\n alias ll='ls -la'\n"
+		rawLines := strings.Split(strings.TrimRight(rawDiff, "\n"), "\n")
+		pagerLines := []string{
+			".bashrc │ 1 +",
+			" 1 │ export EDITOR=vim",
+			" 2 │ export PAGER=less",
+		}
+		m := newTestModel(
+			WithPanelVisible(),
+			WithSize(140, 40),
+		)
+		m.panel.currentPath = "/home/test/.bashrc"
+		m.panel.contentMode = panelModeDiff
+		m.panel.cachePut("/home/test/.bashrc", panelModeDiff, changesSectionDrift, panelCacheEntry{
+			content:      rawDiff,
+			lines:        pagerLines,
+			rawLines:     rawLines,
+			pagerApplied: true,
 		})
 		output := stripForGolden(m.renderFilePanel(panelWidth))
 		golden.RequireEqual(t, []byte(output))

--- a/internal/tui/messages.go
+++ b/internal/tui/messages.go
@@ -19,9 +19,11 @@ type chezmoiStatusLoadedMsg struct {
 }
 
 type chezmoiDiffLoadedMsg struct {
-	path string
-	diff string
-	err  error
+	path         string
+	diff         string // raw unified diff
+	renderedDiff string // pager-colored output (empty if no pager or failed)
+	pagerApplied bool
+	err          error
 }
 
 type chezmoiActionDoneMsg struct {

--- a/internal/tui/messages.go
+++ b/internal/tui/messages.go
@@ -61,9 +61,11 @@ type chezmoiForgetDoneMsg struct {
 }
 
 type chezmoiSourceContentMsg struct {
-	path    string
-	content string
-	err     error
+	path         string
+	content      string // raw content
+	renderedDiff string // pager-colored output (empty if not a diff or no pager)
+	pagerApplied bool
+	err          error
 }
 
 type chezmoiCapturedOutputMsg struct {

--- a/internal/tui/messages.go
+++ b/internal/tui/messages.go
@@ -156,9 +156,11 @@ type templatePathsLoadedMsg struct {
 
 // panelContentLoadedMsg is sent when async panel content loading completes.
 type panelContentLoadedMsg struct {
-	path    string
-	mode    panelContentMode
-	section changesSection
-	content string
-	err     error
+	path         string
+	mode         panelContentMode
+	section      changesSection
+	content      string // raw content
+	rendered     string // pager-rendered output for diff mode (empty if no pager)
+	pagerApplied bool
+	err          error
 }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -52,6 +52,8 @@ type Model struct {
 
 	iconMode IconMode
 
+	diffPagerCmd string // chezmoi diff.pager value; empty = use built-in styling
+
 	width  int
 	height int
 
@@ -164,15 +166,16 @@ func NewModel(opts Options) Model {
 	}
 
 	model := Model{
-		service:     svc,
-		targetPath:  tp,
-		opts:        opts,
-		iconMode:    iconMode,
-		debugLog:    opts.DebugLog,
-		view:        startView,
-		activeTab:   initialTab,
-		tabNames:    tabs,
-		filterInput: ti,
+		service:      svc,
+		targetPath:   tp,
+		opts:         opts,
+		iconMode:     iconMode,
+		diffPagerCmd: opts.DiffPagerCmd,
+		debugLog:     opts.DebugLog,
+		view:         startView,
+		activeTab:    initialTab,
+		tabNames:     tabs,
+		filterInput:  ti,
 		ui: uiState{
 			loading:        statusLoading,
 			loadingSpinner: s,

--- a/internal/tui/options.go
+++ b/internal/tui/options.go
@@ -51,6 +51,11 @@ type Options struct {
 	// Valid values: IconModeNerdFont (default), IconModeUnicode, IconModeNone.
 	IconMode IconMode
 
+	// DiffPagerCmd is the chezmoi diff.pager value (e.g., "delta", "bat").
+	// When set and the pager is in the supported list, diff output is piped
+	// through this command for ANSI-colored rendering.
+	DiffPagerCmd string
+
 	// DebugLog, when non-nil, receives structured JSON logs of every tea.Msg
 	// processed by Update(). Set via the CHEZIT_DEBUG environment variable.
 	DebugLog *slog.Logger

--- a/internal/tui/panel.go
+++ b/internal/tui/panel.go
@@ -27,9 +27,11 @@ type panelCacheKey struct {
 
 // panelCacheEntry holds pre-loaded content for a file.
 type panelCacheEntry struct {
-	content string
-	lines   []string
-	err     error
+	content      string
+	lines        []string // rendered lines for viewport (pager-colored or raw)
+	rawLines     []string // canonical raw diff lines; nil for non-diff content
+	pagerApplied bool
+	err          error
 }
 
 // Panel auto-visibility constants.

--- a/internal/tui/panel_render_test.go
+++ b/internal/tui/panel_render_test.go
@@ -249,7 +249,7 @@ func TestRenderPanelDiffEmptyUntrackedShowsRelevantMessage(t *testing.T) {
 		{Path: "home/private_dot_config/tmux/tmux.conf", StatusCode: "U"},
 	}
 
-	got := m.renderPanelDiff([]string{""}, 80)
+	got := m.renderPanelDiff([]string{""}, 80, false)
 	if !containsAny(got, "Untracked file") {
 		t.Fatalf("expected untracked-specific empty-diff message, got:\n%s", got)
 	}

--- a/internal/tui/panel_update.go
+++ b/internal/tui/panel_update.go
@@ -224,13 +224,19 @@ func (m Model) panelContentCmd(path string, mode panelContentMode, section chang
 			content, err = m.panelLoadContentPreview(path, section)
 		}
 
-		return panelContentLoadedMsg{
+		msg := panelContentLoadedMsg{
 			path:    path,
 			mode:    mode,
 			section: section,
 			content: content,
 			err:     err,
 		}
+		if err == nil && mode == panelModeDiff {
+			rendered, ok := m.renderDiffWithPager(content)
+			msg.rendered = rendered
+			msg.pagerApplied = ok
+		}
+		return msg
 	}
 }
 
@@ -240,12 +246,24 @@ func (m Model) handlePanelContentLoaded(msg panelContentLoadedMsg) (Model, tea.C
 	m.panel.loading = false
 
 	// Cache the result regardless of staleness
-	lines := strings.Split(msg.content, "\n")
-	m.panel.cachePut(msg.path, msg.mode, msg.section, panelCacheEntry{
-		content: msg.content,
-		lines:   lines,
-		err:     msg.err,
-	})
+	rawLines := strings.Split(msg.content, "\n")
+	var lines []string
+	if msg.pagerApplied {
+		lines = strings.Split(msg.rendered, "\n")
+	} else {
+		lines = rawLines
+	}
+
+	entry := panelCacheEntry{
+		content:      msg.content,
+		lines:        lines,
+		err:          msg.err,
+		pagerApplied: msg.pagerApplied,
+	}
+	if msg.mode == panelModeDiff {
+		entry.rawLines = rawLines
+	}
+	m.panel.cachePut(msg.path, msg.mode, msg.section, entry)
 
 	// Stale async guard: only update viewport if this matches current state
 	if msg.path == m.panel.currentPath && msg.mode == m.panel.contentMode && msg.section == m.panel.currentSection {
@@ -317,7 +335,7 @@ func (m Model) panelViewportContentForWidth(contentWidth int) string {
 		if entry.err != nil {
 			return activeTheme.DimText.Render("  " + panelErrorText(entry.err))
 		}
-		return m.renderPanelViewportContent(entry.lines, contentWidth)
+		return m.renderPanelViewportContent(entry.lines, contentWidth, entry.pagerApplied)
 	}
 }
 

--- a/internal/tui/panel_update.go
+++ b/internal/tui/panel_update.go
@@ -345,6 +345,9 @@ func (m Model) syncPanelViewportContent() Model {
 		return m
 	}
 	m.panel.ensureViewport(contentWidth, viewportHeight)
+	if entry, ok := m.panel.cacheGet(m.panel.currentPath, m.panel.contentMode, m.panel.currentSection); ok {
+		m.panel.viewport.SoftWrap = entry.pagerApplied
+	}
 	content := m.panelViewportContentForWidth(contentWidth)
 	currentOffset := m.panel.viewport.YOffset()
 	m.panel.viewport.SetContent(content)

--- a/internal/tui/panel_view.go
+++ b/internal/tui/panel_view.go
@@ -97,7 +97,11 @@ func (m Model) renderPanelTitleBar(width int) string {
 	// Add diff summary, direction hint, and side qualifier if in diff mode
 	if m.panel.contentMode == panelModeDiff {
 		if entry, ok := m.panel.cacheGet(m.panel.currentPath, panelModeDiff, m.panel.currentSection); ok && entry.err == nil {
-			summary := diffSummary(entry.lines)
+			summaryLines := entry.lines
+			if entry.rawLines != nil {
+				summaryLines = entry.rawLines
+			}
+			summary := diffSummary(summaryLines)
 			summaryStr := activeTheme.DimText.Render("  " + summary)
 			title += summaryStr
 		}
@@ -139,25 +143,28 @@ func normalizeLexerName(name string) string {
 }
 
 // renderPanelViewportContent renders the content for the panel viewport.
-func (m Model) renderPanelViewportContent(lines []string, width int) string {
+func (m Model) renderPanelViewportContent(lines []string, width int, pagerApplied bool) string {
 	if m.panel.contentMode == panelModeDiff {
-		return m.renderPanelDiff(lines, width)
+		return m.renderPanelDiff(lines, width, pagerApplied)
 	}
 	return renderPanelFileContent(lines, width, m.panel.currentPath)
 }
 
 // renderPanelDiff renders diff lines with syntax coloring for the panel viewport.
-func (m Model) renderPanelDiff(lines []string, width int) string {
+func (m Model) renderPanelDiff(lines []string, width int, pagerApplied bool) string {
 	if len(lines) == 0 || (len(lines) == 1 && strings.TrimSpace(lines[0]) == "") {
 		return activeTheme.DimText.Render("  " + m.emptyPanelDiffMessage())
 	}
 
 	var b strings.Builder
 	for i, line := range lines {
-		style := diffLineStyle(line)
-		rendered := style.Render(visualTruncate(line, width-2))
 		b.WriteString("  ")
-		b.WriteString(rendered)
+		if pagerApplied {
+			b.WriteString(visualTruncate(line, width-2))
+		} else {
+			style := diffLineStyle(line)
+			b.WriteString(style.Render(visualTruncate(line, width-2)))
+		}
 		if i < len(lines)-1 {
 			b.WriteString("\n")
 		}

--- a/internal/tui/panel_view.go
+++ b/internal/tui/panel_view.go
@@ -158,10 +158,10 @@ func (m Model) renderPanelDiff(lines []string, width int, pagerApplied bool) str
 
 	var b strings.Builder
 	for i, line := range lines {
-		b.WriteString("  ")
 		if pagerApplied {
-			b.WriteString(visualTruncate(line, width-2))
+			b.WriteString(line)
 		} else {
+			b.WriteString("  ")
 			style := diffLineStyle(line)
 			b.WriteString(style.Render(visualTruncate(line, width-2)))
 		}

--- a/internal/tui/status_commands.go
+++ b/internal/tui/status_commands.go
@@ -55,7 +55,11 @@ func (m *Model) annotateTemplateFiles() {
 func (m Model) loadDiffCmd(path string) tea.Cmd {
 	return func() tea.Msg {
 		diff, err := m.service.Diff(path)
-		return chezmoiDiffLoadedMsg{path: path, diff: diff, err: err}
+		if err != nil {
+			return chezmoiDiffLoadedMsg{path: path, diff: diff, err: err}
+		}
+		rendered, ok := m.renderDiffWithPager(diff)
+		return chezmoiDiffLoadedMsg{path: path, diff: diff, renderedDiff: rendered, pagerApplied: ok, err: err}
 	}
 }
 
@@ -290,7 +294,11 @@ func (m Model) gitResetAllCmd() tea.Cmd {
 func (m Model) loadGitDiffCmd(path string, staged bool) tea.Cmd {
 	return func() tea.Msg {
 		diff, err := m.service.GitDiff(path, staged)
-		return chezmoiDiffLoadedMsg{path: path, diff: diff, err: err}
+		if err != nil {
+			return chezmoiDiffLoadedMsg{path: path, diff: diff, err: err}
+		}
+		rendered, ok := m.renderDiffWithPager(diff)
+		return chezmoiDiffLoadedMsg{path: path, diff: diff, renderedDiff: rendered, pagerApplied: ok, err: err}
 	}
 }
 

--- a/internal/tui/status_update.go
+++ b/internal/tui/status_update.go
@@ -243,7 +243,11 @@ func (m Model) handleStatusEnter(row changesRow) (tea.Model, tea.Cmd) {
 			m.ui.message = ""
 			return m, tea.Batch(m.ui.loadingSpinner.Tick, func() tea.Msg {
 				content, err := m.service.GitShow(row.commit.Hash)
-				return chezmoiDiffLoadedMsg{path: row.commit.Hash, diff: content, err: err}
+				if err != nil {
+					return chezmoiDiffLoadedMsg{path: row.commit.Hash, diff: content, err: err}
+				}
+				rendered, ok := m.renderDiffWithPager(content)
+				return chezmoiDiffLoadedMsg{path: row.commit.Hash, diff: content, renderedDiff: rendered, pagerApplied: ok}
 			})
 		}
 	}

--- a/internal/tui/testdata/TestGoldenDiffView/pager_mode.golden
+++ b/internal/tui/testdata/TestGoldenDiffView/pager_mode.golden
@@ -1,0 +1,41 @@
+ chezit > Status > .bashrc
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  - on disk  + source
+.bashrc │ 1 +
+ 1 │ export EDITOR=vim
+ 2 │ export PAGER=less
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  +1/-0 lines | - on disk  + source | line 1/3
+↑/↓ scroll  ^d/^u half-page  g top  G bottom  e edit  a actions  esc back

--- a/internal/tui/testdata/TestGoldenPanel/diff_mode_pager.golden
+++ b/internal/tui/testdata/TestGoldenPanel/diff_mode_pager.golden
@@ -1,0 +1,5 @@
+│ .bashrc [diff]  +1/-0 lines
+│   - on disk  + source
+│ .bashrc │ 1 +
+│  1 │ export EDITOR=vim
+│  2 │ export PAGER=less

--- a/internal/tui/theme.go
+++ b/internal/tui/theme.go
@@ -52,6 +52,8 @@ type Theme struct {
 	Panel lipgloss.Style
 
 	ChromaStyleName string
+
+	IsDark bool
 }
 
 var activeTheme = ThemeDark()
@@ -150,6 +152,7 @@ func newTheme(flavor catppuccin.Flavor, isDark bool) Theme {
 		SubtleText: lipgloss.Color(flavor.Subtext0().Hex),
 
 		ChromaStyleName: chromaStyle,
+		IsDark:          isDark,
 	}
 
 	t.Selected = lipgloss.NewStyle().

--- a/internal/tui/types.go
+++ b/internal/tui/types.go
@@ -314,6 +314,7 @@ func (d *diffViewState) ensureViewport(width, height int) {
 		d.viewport = viewport.New()
 		d.viewport.SetWidth(width)
 		d.viewport.SetHeight(height)
+		d.viewport.SoftWrap = d.pagerApplied
 		d.viewportReady = true
 		d.lastWidth = width
 	}

--- a/internal/tui/types.go
+++ b/internal/tui/types.go
@@ -298,7 +298,9 @@ func isApplyAction(action chezmoiAction) bool {
 type diffViewState struct {
 	content       string
 	path          string
-	lines         []string
+	lines         []string // rendered lines for viewport (pager-colored or raw)
+	rawLines      []string // canonical raw unified diff lines (for diffSummary)
+	pagerApplied  bool
 	sourceSection changesSection
 	previewApply  bool
 	viewport      viewport.Model
@@ -326,6 +328,15 @@ func (d *diffViewState) ensureViewport(width, height int) {
 // resetViewport marks the viewport as uninitialized so it will be recreated on next use.
 func (d *diffViewState) resetViewport() {
 	d.viewportReady = false
+}
+
+// clear resets all diff view state fields.
+func (d *diffViewState) clear() {
+	d.content = ""
+	d.lines = nil
+	d.rawLines = nil
+	d.pagerApplied = false
+	d.resetViewport()
 }
 
 // filesSearchMetrics captures per-run deep-search telemetry for debugging/tests.

--- a/internal/tui/update_crosscutting.go
+++ b/internal/tui/update_crosscutting.go
@@ -22,7 +22,14 @@ func (m Model) handleDiffLoaded(msg chezmoiDiffLoadedMsg) (tea.Model, tea.Cmd) {
 	m.view = DiffScreen
 	m.diff.content = msg.diff
 	m.diff.path = msg.path
-	m.diff.lines = strings.Split(msg.diff, "\n")
+	m.diff.rawLines = strings.Split(msg.diff, "\n")
+	if msg.pagerApplied {
+		m.diff.lines = strings.Split(msg.renderedDiff, "\n")
+		m.diff.pagerApplied = true
+	} else {
+		m.diff.lines = m.diff.rawLines
+		m.diff.pagerApplied = false
+	}
 	m.diff.resetViewport()
 	m.actions.show = false
 	return m, nil
@@ -178,9 +185,7 @@ func (m Model) handleExecDone(msg chezmoiExecDoneMsg) (tea.Model, tea.Cmd) {
 	}
 	if m.view == DiffScreen {
 		m.view = StatusScreen
-		m.diff.content = ""
-		m.diff.lines = nil
-		m.diff.resetViewport()
+		m.diff.clear()
 	}
 	if !reload {
 		return m, nil

--- a/internal/tui/update_crosscutting.go
+++ b/internal/tui/update_crosscutting.go
@@ -94,7 +94,14 @@ func (m Model) handleSourceContent(msg chezmoiSourceContentMsg) (tea.Model, tea.
 	m.view = DiffScreen
 	m.diff.content = msg.content
 	m.diff.path = msg.path
-	m.diff.lines = strings.Split(msg.content, "\n")
+	m.diff.rawLines = strings.Split(msg.content, "\n")
+	if msg.pagerApplied {
+		m.diff.lines = strings.Split(msg.renderedDiff, "\n")
+		m.diff.pagerApplied = true
+	} else {
+		m.diff.lines = m.diff.rawLines
+		m.diff.pagerApplied = false
+	}
 	m.diff.resetViewport()
 	m.actions.show = false
 	return m, nil
@@ -118,7 +125,9 @@ func (m Model) handleCapturedOutput(msg chezmoiCapturedOutputMsg) (tea.Model, te
 	m.view = DiffScreen
 	m.diff.content = msg.output
 	m.diff.path = msg.label
-	m.diff.lines = strings.Split(msg.output, "\n")
+	m.diff.rawLines = strings.Split(msg.output, "\n")
+	m.diff.lines = m.diff.rawLines
+	m.diff.pagerApplied = false
 	m.diff.resetViewport()
 	m.actions.show = false
 	m.panel.clearCache()

--- a/internal/tui/update_diff.go
+++ b/internal/tui/update_diff.go
@@ -42,15 +42,11 @@ func (m Model) handleDiffKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		case key.Matches(msg, ChezSharedKeys.Back):
 			m.diff.previewApply = false
 			m.view = StatusScreen
-			m.diff.content = ""
-			m.diff.lines = nil
-			m.diff.resetViewport()
+			m.diff.clear()
 			return m, nil
 		case key.Matches(msg, ChezCommandKeys.Run): // Enter
 			m.diff.previewApply = false
-			m.diff.content = ""
-			m.diff.lines = nil
-			m.diff.resetViewport()
+			m.diff.clear()
 			m.actions.show = false
 			m = m.showConfirmScreen(chezmoiActionApplyAll, "apply all changes to destination")
 			m.overlays.applyWrapTTY = true
@@ -62,9 +58,7 @@ func (m Model) handleDiffKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	switch {
 	case key.Matches(msg, ChezSharedKeys.Back):
 		m.view = StatusScreen
-		m.diff.content = ""
-		m.diff.lines = nil
-		m.diff.resetViewport()
+		m.diff.clear()
 		m.actions.show = false
 		return m, nil
 
@@ -93,7 +87,7 @@ func (m Model) syncDiffViewportContent() Model {
 	}
 	diffHeight := m.chezmoiDiffViewHeight()
 	m.diff.ensureViewport(m.effectiveWidth(), diffHeight)
-	content := preRenderDiffContent(m.diff.lines, m.effectiveWidth())
+	content := preRenderDiffContent(m.diff.lines, m.effectiveWidth(), m.diff.pagerApplied)
 	currentOffset := m.diff.viewport.YOffset()
 	m.diff.viewport.SetContent(content)
 	m.diff.viewport.SetYOffset(currentOffset)

--- a/internal/tui/view_overlays.go
+++ b/internal/tui/view_overlays.go
@@ -43,7 +43,7 @@ func (m Model) renderDiffView() string {
 		diffHeight := m.chezmoiDiffViewHeight()
 		m.diff.ensureViewport(m.effectiveWidth(), diffHeight)
 
-		content := preRenderDiffContent(m.diff.lines, m.effectiveWidth())
+		content := preRenderDiffContent(m.diff.lines, m.effectiveWidth(), m.diff.pagerApplied)
 		offset := m.diff.viewport.YOffset()
 		m.diff.viewport.SetContent(content)
 		m.diff.viewport.SetYOffset(offset)
@@ -128,7 +128,7 @@ func applyConfirmDescription(action chezmoiAction, force bool) string {
 }
 
 func (m Model) renderChezmoiDiffStatus() string {
-	summary := diffSummary(m.diff.lines)
+	summary := diffSummary(m.diffRawLines())
 	if hint := diffDirectionHint(m.diff.sourceSection); hint != "" {
 		summary = summary + " | " + hint
 	}


### PR DESCRIPTION
Adds support for `chezmoi` `diff.pager` in the TUI.

- Reads `diff.pager` from chezmoi config and pipes diff output through it before rendering
- Supports an initial set of pagers: `delta`, `bat`, and `diff-so-fancy`
- Applies pager rendering to full-screen diff views, panel diff preview, apply preview, and the diff-all command

This preserves pager-provided diff formatting, spacing, gutters, and color inside chezit's diff views. `diff.command` is still out of scope.


If the configured pager is unsupported, missing, or fails, chezit falls back to the built-in diff renderer.

Closes #20