### PR TITLE
feat: add diff pager opt-out config

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ mode: write          # write | read_only
 panel: auto          # auto | show | hide
 commit_presets: []   # e.g. ["dotfiles: update config"]
 binary_path: ""      # e.g. /opt/homebrew/bin/chezmoi (only needed when chezmoi is not on $PATH)
+diff_builtin: false  # true = ignore chezmoi diff.pager and use chezit's built-in diff rendering
 ```
 
 Colors adapt automatically to your terminal background (dark or light) at startup using Catppuccin palettes.
@@ -177,6 +178,7 @@ Defaults are shown in the YAML example above.
 | `panel` | `auto`, `show`, `hide` | `auto` shows the preview only when terminal width allows. |
 | `commit_presets` | list of strings | Optional preset commit messages shown in the commit flow. |
 | `binary_path` | path to `chezmoi` binary (`~` supported) | Set only if `chezmoi` is not on `PATH`. |
+| `diff_builtin` | `true`, `false` | When `true`, bypass chezmoi's `diff.pager` and use chezit's built-in diff rendering instead. |
 
 ## Diff Pager Support
 
@@ -189,6 +191,8 @@ chezit respects chezmoi's `diff.pager` setting. When a supported pager is config
 ```
 
 Supported pagers: `delta`, `bat`, `diff-so-fancy`. If the configured pager is missing or fails, chezit falls back silently to built-in styling. To request support for a new pager, open an issue or PR.
+
+If you want to keep a pager configured for regular `chezmoi` CLI use but bypass it in chezit, set `diff_builtin: true` in `~/.config/chezit/config.yaml`. chezit will use its built-in diff rendering instead. This only affects chezit.
 
 ## Development
 

--- a/cmd/chezit/main.go
+++ b/cmd/chezit/main.go
@@ -89,8 +89,10 @@ func runTUI(initialTab string) error {
 	}
 
 	var diffPagerCmd string
-	if diffCfg, err := svc.DiffConfig(); err == nil {
-		diffPagerCmd = diffCfg.Pager
+	if !cfg.DiffBuiltin {
+		if diffCfg, err := svc.DiffConfig(); err == nil {
+			diffPagerCmd = diffCfg.Pager
+		}
 	}
 
 	opts := tui.Options{

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -37,6 +37,7 @@ type Config struct {
 	Mode          Mode     `yaml:"mode"`
 	BinaryPath    string   `yaml:"binary_path"`
 	CommitPresets []string `yaml:"commit_presets"`
+	DiffBuiltin   bool     `yaml:"diff_builtin"`
 }
 
 func Default() Config {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -76,6 +76,33 @@ commit_presets:
 	}
 }
 
+func TestLoadFromParsesDiffBuiltin(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(path, []byte(`
+diff_builtin: true
+`), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	cfg, err := LoadFrom(path)
+	if err != nil {
+		t.Fatalf("LoadFrom: %v", err)
+	}
+	if !cfg.DiffBuiltin {
+		t.Fatalf("expected diff_builtin true, got false")
+	}
+}
+
+func TestLoadFromDiffBuiltinDefaultsFalse(t *testing.T) {
+	cfg, err := LoadFrom(filepath.Join(t.TempDir(), "missing.yaml"))
+	if err != nil {
+		t.Fatalf("LoadFrom: %v", err)
+	}
+	if cfg.DiffBuiltin {
+		t.Fatalf("expected diff_builtin default false, got true")
+	}
+}
+
 func TestNormalizeIconsTrimsAndLowercases(t *testing.T) {
 	cfg := Config{
 		Icons: "  NerdFont  ",


### PR DESCRIPTION
Adds a `diff_builtin` config option to bypass `chezmoi`'s `diff.pager` in the TUI.

- Add `diff_builtin` to chezit config
- Skip reading `diff.pager` when `diff_builtin: true`
- Keep the current pager-respecting behavior by default
- Add new config option in the README

When `diff_builtin` is unset or `false`, chezit still respects `chezmoi`'s `diff.pager` as before.
