### PR TITLE
fix: consistent statusbar position

### DIFF
--- a/internal/tui/layout.go
+++ b/internal/tui/layout.go
@@ -4,10 +4,14 @@ package tui
 
 // Layout constants shared between rendering and mouse-hit-testing.
 const (
+	// commonHeaderLines is the number of header rows for all tabs
+	// tabs: breadcrumb + separator + tab bar + padding
+	commonHeaderLines = 3
+
 	// statusFilesHeaderLines is the number of header rows above the list
 	// in the Status and Files tabs: breadcrumb + separator + tab bar +
 	// search box + git header + summary line.
-	statusFilesHeaderLines = 7
+	statusFilesHeaderLines = commonHeaderLines + 4
 
 	// statusFilesFooterLines is the number of footer rows below the list:
 	// status bar + help line.

--- a/internal/tui/testdata/TestGoldenActionsMenu/status_tab.golden
+++ b/internal/tui/testdata/TestGoldenActionsMenu/status_tab.golden
@@ -21,5 +21,20 @@
   Apply All
   Update (pull + apply)
   Refresh
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
   2 drift | 0 unstaged | 0 staged | 3/7 | diverged
 ↑/↓ navigate  enter select  esc back

--- a/internal/tui/testdata/TestGoldenErrorStates/status_load_error.golden
+++ b/internal/tui/testdata/TestGoldenErrorStates/status_load_error.golden
@@ -6,5 +6,35 @@
 ╰─────────────────────────────────────────────────────────────────╯
   ⣾  Loading git status...
   No changes
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
   chezmoi status: exit status 1
 ↑/↓ nav  enter diff  a actions  c commit  r refresh  v switch diff/content  l/→ focus preview  p hide preview  esc quit

--- a/internal/tui/testdata/TestGoldenFilterOverlay/active_with_query.golden
+++ b/internal/tui/testdata/TestGoldenFilterOverlay/active_with_query.golden
@@ -8,6 +8,34 @@
   ▼ .config [2 files]
   └── ▶ nvim [2 files]
   .bashrc
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
   .config [view:managed] [filter:all]
 ↑/↓ nav  enter open/toggle  a actions  t flat  f view/filter  r refresh  v switch diff/content  l/→ focus preview
 p hide preview  ? keys  esc back

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -69,22 +69,23 @@ func (m Model) View() tea.View {
 	b.WriteString(renderSeparator(m.effectiveWidth()))
 	b.WriteString("\n")
 	b.WriteString(m.renderChezmoiTabBar())
-	b.WriteString("\n")
 
+	var tabContent string
 	switch m.activeTabName() {
 	case "Status":
-		b.WriteString(m.renderChangesTabWithPanel())
+		tabContent = m.renderChangesTabWithPanel()
 	case "Files":
-		b.WriteString(m.renderManagedTabWithPanel())
+		tabContent = m.renderManagedTabWithPanel()
 	case "Info":
-		b.WriteString(m.renderInfoTabContent())
+		tabContent = m.renderInfoTabContent()
 	case "Commands":
-		b.WriteString(m.renderCommandsTabContent())
+		tabContent = m.renderCommandsTabContent()
 	}
 
-	b.WriteString("\n")
-	b.WriteString(m.renderChezmoiTabStatus())
-	v.Content = lipgloss.Place(m.width, m.height, lipgloss.Left, lipgloss.Top, b.String())
+	statusBar := m.renderChezmoiTabStatus()
+	contentHeight := m.height - commonHeaderLines - statusFilesFooterLines
+	content := lipgloss.Place(m.width, contentHeight, lipgloss.Left, lipgloss.Top, tabContent)
+	v.Content = lipgloss.JoinVertical(lipgloss.Top, b.String(), content, statusBar)
 	return v
 }
 


### PR DESCRIPTION
The status bar is jumping around between the different tabs.

This PR anchors the status bar to the bottom of the screen independently of a tab's content for a more consistent layout throughout.