### PR TITLE
feat(config): support custom chezmoi config path

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ mode: write          # write | read_only
 panel: auto          # auto | show | hide
 commit_presets: []   # e.g. ["dotfiles: update config"]
 binary_path: ""      # e.g. /opt/homebrew/bin/chezmoi (only needed when chezmoi is not on $PATH)
+chezmoi_config_path: "" # optional custom chezmoi config file path (equivalent to --config)
 diff_builtin: false  # true = ignore chezmoi diff.pager and use chezit's built-in diff rendering
 ```
 
@@ -178,6 +179,7 @@ Defaults are shown in the YAML example above.
 | `panel` | `auto`, `show`, `hide` | `auto` shows the preview only when terminal width allows. |
 | `commit_presets` | list of strings | Optional preset commit messages shown in the commit flow. |
 | `binary_path` | path to `chezmoi` binary (`~` supported) | Set only if `chezmoi` is not on `PATH`. |
+| `chezmoi_config_path` | path to chezmoi config file (`~` supported) | Optional. Use to force chezit to run every chezmoi command with `--config <path>`. |
 | `diff_builtin` | `true`, `false` | When `true`, bypass chezmoi's `diff.pager` and use chezit's built-in diff rendering instead. |
 
 ## Diff Pager Support

--- a/cmd/chezit/main.go
+++ b/cmd/chezit/main.go
@@ -65,7 +65,10 @@ func runTUI(initialTab string) error {
 		return fmt.Errorf("error loading config: %w", err)
 	}
 
-	client := chezmoi.New(chezmoi.WithBinaryPath(cfg.BinaryPath))
+	client := chezmoi.New(
+		chezmoi.WithBinaryPath(cfg.BinaryPath),
+		chezmoi.WithConfigPath(cfg.ChezmoiConfig),
+	)
 	tp, err := client.TargetPath()
 	if err != nil {
 		return fmt.Errorf("could not determine chezmoi target path: %w", err)

--- a/internal/chezmoi/client.go
+++ b/internal/chezmoi/client.go
@@ -19,6 +19,7 @@ import (
 type Client struct {
 	Timeout    time.Duration
 	BinaryPath string
+	ConfigPath string
 	Editor     string
 }
 
@@ -33,6 +34,12 @@ func WithTimeout(d time.Duration) Option {
 func WithBinaryPath(path string) Option {
 	return func(c *Client) {
 		c.BinaryPath = strings.TrimSpace(path)
+	}
+}
+
+func WithConfigPath(path string) Option {
+	return func(c *Client) {
+		c.ConfigPath = strings.TrimSpace(path)
 	}
 }
 
@@ -70,13 +77,17 @@ func (c *Client) binary() string {
 // These ensure machine-parseable output with no TTY prompts, pager, color
 // codes, progress bars, or external diff tool interference.
 func (c *Client) baseFlags() []string {
-	return []string{
+	flags := []string{
 		"--no-tty",
 		"--color=false",
 		"--no-pager",
 		"--progress=false",
 		"--use-builtin-diff",
 	}
+	if c.ConfigPath != "" {
+		flags = append(flags, "--config", c.ConfigPath)
+	}
+	return flags
 }
 
 func (c *Client) cmd(args ...string) (*exec.Cmd, context.CancelFunc) {

--- a/internal/chezmoi/client.go
+++ b/internal/chezmoi/client.go
@@ -73,6 +73,13 @@ func (c *Client) binary() string {
 	return c.BinaryPath
 }
 
+func (c *Client) configFlags() []string {
+	if c.ConfigPath == "" {
+		return nil
+	}
+	return []string{"--config", c.ConfigPath}
+}
+
 // baseFlags returns flags injected into every non-interactive command.
 // These ensure machine-parseable output with no TTY prompts, pager, color
 // codes, progress bars, or external diff tool interference.
@@ -84,10 +91,13 @@ func (c *Client) baseFlags() []string {
 		"--progress=false",
 		"--use-builtin-diff",
 	}
-	if c.ConfigPath != "" {
-		flags = append(flags, "--config", c.ConfigPath)
-	}
+	flags = append(flags, c.configFlags()...)
 	return flags
+}
+
+func (c *Client) command(args ...string) *exec.Cmd {
+	allArgs := append(c.configFlags(), args...)
+	return exec.Command(c.binary(), allArgs...)
 }
 
 func (c *Client) cmd(args ...string) (*exec.Cmd, context.CancelFunc) {
@@ -356,35 +366,35 @@ func (c *Client) GitRoot() (string, error) {
 }
 
 func (c *Client) ApplyRefreshCmd() *exec.Cmd {
-	return exec.Command(c.binary(), "apply", "--refresh-externals")
+	return c.command("apply", "--refresh-externals")
 }
 
 func (c *Client) ApplyCmd(filePath string) *exec.Cmd {
-	return exec.Command(c.binary(), "apply", filePath)
+	return c.command("apply", filePath)
 }
 
 func (c *Client) ApplyAllCmd() *exec.Cmd {
-	return exec.Command(c.binary(), "apply")
+	return c.command("apply")
 }
 
 func (c *Client) ApplyForceCmd(filePath string) *exec.Cmd {
-	return exec.Command(c.binary(), "apply", "--force", filePath)
+	return c.command("apply", "--force", filePath)
 }
 
 func (c *Client) ApplyAllForceCmd() *exec.Cmd {
-	return exec.Command(c.binary(), "apply", "--force")
+	return c.command("apply", "--force")
 }
 
 func (c *Client) ApplyDryRunCmd() *exec.Cmd {
-	return exec.Command(c.binary(), "apply", "--dry-run", "-v")
+	return c.command("apply", "--dry-run", "-v")
 }
 
 func (c *Client) ApplyRefreshDryRunCmd() *exec.Cmd {
-	return exec.Command(c.binary(), "apply", "--refresh-externals", "--dry-run", "-v")
+	return c.command("apply", "--refresh-externals", "--dry-run", "-v")
 }
 
 func (c *Client) UpdateCmd() *exec.Cmd {
-	return exec.Command(c.binary(), "update")
+	return c.command("update")
 }
 
 // Forget runs `chezmoi forget --force`.
@@ -412,7 +422,7 @@ func (c *Client) applyEditorEnv(cmd *exec.Cmd) {
 }
 
 func (c *Client) EditCmd(filePath string) *exec.Cmd {
-	cmd := exec.Command(c.binary(), "edit", filePath)
+	cmd := c.command("edit", filePath)
 	c.applyEditorEnv(cmd)
 	return cmd
 }
@@ -520,7 +530,7 @@ func (c *Client) GitBranchInfo() (GitInfo, error) {
 }
 
 func (c *Client) EditSourceCmd() *exec.Cmd {
-	cmd := exec.Command(c.binary(), "edit")
+	cmd := c.command("edit")
 	c.applyEditorEnv(cmd)
 	return cmd
 }
@@ -539,7 +549,7 @@ func (c *Client) Doctor() (string, error) {
 }
 
 func (c *Client) EditConfigCmd() *exec.Cmd {
-	cmd := exec.Command(c.binary(), "edit-config")
+	cmd := c.command("edit-config")
 	c.applyEditorEnv(cmd)
 	return cmd
 }
@@ -709,13 +719,13 @@ func (c *Client) CatConfig() (string, error) {
 }
 
 func (c *Client) InitCmd() *exec.Cmd {
-	return exec.Command(c.binary(), "init")
+	return c.command("init")
 }
 
 // EditConfigTemplateCmd opens `chezmoi edit-config-template`.
 // If no template exists, chezmoi creates one from the current config.
 func (c *Client) EditConfigTemplateCmd() *exec.Cmd {
-	cmd := exec.Command(c.binary(), "edit-config-template")
+	cmd := c.command("edit-config-template")
 	c.applyEditorEnv(cmd)
 	return cmd
 }

--- a/internal/chezmoi/client_test.go
+++ b/internal/chezmoi/client_test.go
@@ -36,7 +36,7 @@ func TestClientBaseFlagsIncludesConfigPath(t *testing.T) {
 	flags := client.baseFlags()
 
 	hasConfig := false
-	for i := 0; i < len(flags)-1; i++ {
+	for i := range len(flags) - 1 {
 		if flags[i] == "--config" && flags[i+1] == "/tmp/chezmoi.toml" {
 			hasConfig = true
 			break

--- a/internal/chezmoi/client_test.go
+++ b/internal/chezmoi/client_test.go
@@ -29,6 +29,23 @@ func TestClientBaseFlagsContents(t *testing.T) {
 	}
 }
 
+func TestClientBaseFlagsIncludesConfigPath(t *testing.T) {
+	client := New(WithConfigPath("/tmp/chezmoi.toml"))
+	flags := client.baseFlags()
+
+	hasConfig := false
+	for i := 0; i < len(flags)-1; i++ {
+		if flags[i] == "--config" && flags[i+1] == "/tmp/chezmoi.toml" {
+			hasConfig = true
+			break
+		}
+	}
+
+	if !hasConfig {
+		t.Fatalf("expected --config flag with custom path, got %v", flags)
+	}
+}
+
 func TestClientCmdInjectsBaseFlags(t *testing.T) {
 	binaryPath := writeFakeChezmoiRawArgsBinary(t)
 
@@ -46,6 +63,24 @@ func TestClientCmdInjectsBaseFlags(t *testing.T) {
 	}
 	if !strings.Contains(args, "status") {
 		t.Errorf("expected subcommand 'status' in args, got: %s", args)
+	}
+}
+
+func TestClientCmdInjectsConfigPathFlag(t *testing.T) {
+	binaryPath := writeFakeChezmoiRawArgsBinary(t)
+
+	client := New(
+		WithBinaryPath(binaryPath),
+		WithConfigPath("/tmp/custom.toml"),
+	)
+	output, err := client.run("status")
+	if err != nil {
+		t.Fatalf("run returned unexpected error: %v", err)
+	}
+
+	args := strings.TrimSpace(string(output))
+	if !strings.Contains(args, "--config /tmp/custom.toml") {
+		t.Fatalf("expected custom config flag in args, got: %s", args)
 	}
 }
 

--- a/internal/chezmoi/client_test.go
+++ b/internal/chezmoi/client_test.go
@@ -2,7 +2,9 @@ package chezmoi
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -81,6 +83,60 @@ func TestClientCmdInjectsConfigPathFlag(t *testing.T) {
 	args := strings.TrimSpace(string(output))
 	if !strings.Contains(args, "--config /tmp/custom.toml") {
 		t.Fatalf("expected custom config flag in args, got: %s", args)
+	}
+}
+
+func TestCommandConstructorsIncludeConfigFlag(t *testing.T) {
+	client := New(WithConfigPath("/tmp/custom.toml"))
+
+	tests := []struct {
+		name string
+		cmd  *exec.Cmd
+		want []string
+	}{
+		{name: "ApplyRefreshCmd", cmd: client.ApplyRefreshCmd(), want: []string{"--config", "/tmp/custom.toml", "apply", "--refresh-externals"}},
+		{name: "ApplyCmd", cmd: client.ApplyCmd("/tmp/file"), want: []string{"--config", "/tmp/custom.toml", "apply", "/tmp/file"}},
+		{name: "ApplyAllCmd", cmd: client.ApplyAllCmd(), want: []string{"--config", "/tmp/custom.toml", "apply"}},
+		{name: "ApplyForceCmd", cmd: client.ApplyForceCmd("/tmp/file"), want: []string{"--config", "/tmp/custom.toml", "apply", "--force", "/tmp/file"}},
+		{name: "ApplyAllForceCmd", cmd: client.ApplyAllForceCmd(), want: []string{"--config", "/tmp/custom.toml", "apply", "--force"}},
+		{name: "ApplyDryRunCmd", cmd: client.ApplyDryRunCmd(), want: []string{"--config", "/tmp/custom.toml", "apply", "--dry-run", "-v"}},
+		{name: "ApplyRefreshDryRunCmd", cmd: client.ApplyRefreshDryRunCmd(), want: []string{"--config", "/tmp/custom.toml", "apply", "--refresh-externals", "--dry-run", "-v"}},
+		{name: "UpdateCmd", cmd: client.UpdateCmd(), want: []string{"--config", "/tmp/custom.toml", "update"}},
+		{name: "EditCmd", cmd: client.EditCmd("/tmp/file"), want: []string{"--config", "/tmp/custom.toml", "edit", "/tmp/file"}},
+		{name: "EditSourceCmd", cmd: client.EditSourceCmd(), want: []string{"--config", "/tmp/custom.toml", "edit"}},
+		{name: "EditConfigCmd", cmd: client.EditConfigCmd(), want: []string{"--config", "/tmp/custom.toml", "edit-config"}},
+		{name: "InitCmd", cmd: client.InitCmd(), want: []string{"--config", "/tmp/custom.toml", "init"}},
+		{name: "EditConfigTemplateCmd", cmd: client.EditConfigTemplateCmd(), want: []string{"--config", "/tmp/custom.toml", "edit-config-template"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if !slices.Equal(tt.cmd.Args[1:], tt.want) {
+				t.Fatalf("args mismatch: got %v, want %v", tt.cmd.Args[1:], tt.want)
+			}
+		})
+	}
+}
+
+func TestCommandConstructorsWithoutConfigFlag(t *testing.T) {
+	client := New()
+
+	tests := []struct {
+		name string
+		cmd  *exec.Cmd
+	}{
+		{name: "ApplyCmd", cmd: client.ApplyCmd("/tmp/file")},
+		{name: "UpdateCmd", cmd: client.UpdateCmd()},
+		{name: "EditConfigCmd", cmd: client.EditConfigCmd()},
+		{name: "InitCmd", cmd: client.InitCmd()},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if slices.Contains(tt.cmd.Args[1:], "--config") {
+				t.Fatalf("did not expect --config in args: %v", tt.cmd.Args[1:])
+			}
+		})
 	}
 }
 
@@ -215,7 +271,7 @@ func writeFakeChezmoiClientBinary(t *testing.T, body string) string {
 	// Skip leading --flags injected by Client.baseFlags() so the
 	// case statements in test scripts can match on the subcommand.
 	preamble := "#!/bin/sh\nset -eu\n" +
-		"while [ $# -gt 0 ]; do case \"$1\" in --*) shift ;; *) break ;; esac; done\n"
+		"while [ $# -gt 0 ]; do case \"$1\" in --config) shift 2 ;; --*) shift ;; *) break ;; esac; done\n"
 	script := preamble + strings.TrimSpace(body) + "\n"
 	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
 		t.Fatalf("write fake chezmoi binary: %v", err)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -36,6 +36,7 @@ type Config struct {
 	Icons         string   `yaml:"icons"` // "nerdfont" (default), "unicode", "none"
 	Mode          Mode     `yaml:"mode"`
 	BinaryPath    string   `yaml:"binary_path"`
+	ChezmoiConfig string   `yaml:"chezmoi_config_path"`
 	CommitPresets []string `yaml:"commit_presets"`
 	DiffBuiltin   bool     `yaml:"diff_builtin"`
 }
@@ -57,6 +58,11 @@ func (c *Config) Normalize() {
 	c.BinaryPath = strings.TrimSpace(c.BinaryPath)
 	if c.BinaryPath != "" {
 		c.BinaryPath = expandPath(c.BinaryPath)
+	}
+
+	c.ChezmoiConfig = strings.TrimSpace(c.ChezmoiConfig)
+	if c.ChezmoiConfig != "" {
+		c.ChezmoiConfig = expandPath(c.ChezmoiConfig)
 	}
 	if len(c.CommitPresets) > 0 {
 		c.CommitPresets = normalizeStringList(c.CommitPresets)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -24,6 +24,7 @@ func TestLoadFromParsesFlatConfig(t *testing.T) {
 	if err := os.WriteFile(path, []byte(`
 mode: read_only
 binary_path: ~/bin/chezmoi-edge
+chezmoi_config_path: ~/.config/chezmoi/work.toml
 commit_presets:
   - "from chezmoi"
 `), 0o600); err != nil {
@@ -39,6 +40,9 @@ commit_presets:
 	}
 	if cfg.BinaryPath == "~/bin/chezmoi-edge" || cfg.BinaryPath == "" {
 		t.Fatalf("expected expanded binary path, got %q", cfg.BinaryPath)
+	}
+	if cfg.ChezmoiConfig == "~/.config/chezmoi/work.toml" || cfg.ChezmoiConfig == "" {
+		t.Fatalf("expected expanded chezmoi config path, got %q", cfg.ChezmoiConfig)
 	}
 	if len(cfg.CommitPresets) != 1 || cfg.CommitPresets[0] != "from chezmoi" {
 		t.Fatalf("unexpected commit presets: %#v", cfg.CommitPresets)


### PR DESCRIPTION
## Summary
- add `chezmoi_config_path` to chezit config
- pass the custom config path to chezmoi CLI calls via `--config <path>`
- document the new option in README configuration section
- add tests for config parsing and command flag injection
- ensure direct command constructors (apply/edit/update/init) also honor custom config path

## Changes
- `internal/config/config.go`
  - add `ChezmoiConfig` (`yaml:"chezmoi_config_path"`)
  - normalize/expand `~` for the custom path
- `cmd/chezit/main.go`
  - wire config value into chezmoi client creation
- `internal/chezmoi/client.go`
  - add `ConfigPath` to client options
  - add `WithConfigPath(...)`
  - extract `configFlags()` and `command(...)` helpers
  - include `--config <path>` in non-interactive base flags
  - make direct command constructors use `command(...)` so they also include `--config`
- tests
  - `internal/config/config_test.go`
  - `internal/chezmoi/client_test.go`
    - verify `--config` injection in `run(...)` path
    - verify `--config` injection in direct command constructors
    - verify no `--config` when unset
    - improve fake binary preamble to handle `--config <value>`
- docs
  - `README.md` config example + table

## Validation
- `go test ./internal/config/... ./internal/chezmoi/...`
- `go test ./...`

Results:
- ✅ All listed commands passed locally.
